### PR TITLE
GroupBy: support expression group keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ df = out.collect()
   - **set-like**: `concat_vertical`
   - **dedupe**: `unique`, `duplicated`
   - **joins**: `join` (`on` / `left_on` / `right_on` may mix column names and `Expr` keys)
-  - **grouping**: `group_by(...).agg(...)`
+  - **grouping**: `group_by(...).agg(...)` (keys may be column names or expressions; expression keys appear as `__pf_g0`, `__pf_g1`, … in the result schema)
   - **core**: `with_column`, `cast`, `filter`, `sort` (keys may be column names and/or `Expr`; schema unchanged)
 - **Boundaries**:
   - `collect()` executes the accumulated plan using the adapter/backend

--- a/docs/guides/planframe/examples/rows_adapter_minimal.py
+++ b/docs/guides/planframe/examples/rows_adapter_minimal.py
@@ -110,7 +110,7 @@ class RowsAdapter(BaseAdapter[RowsFrame, Expr[object]]):
         self,
         df: RowsFrame,
         *,
-        keys: tuple[str, ...],
+        keys: tuple[CompiledJoinKey[Expr[object]], ...],
         named_aggs: dict[str, tuple[str, str]],
     ) -> RowsFrame:
         raise NotImplementedError("RowsAdapter example does not implement group_by_agg")

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -130,11 +130,19 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
         self,
         df: PolarsBackendFrame,
         *,
-        keys: tuple[str, ...],
+        keys: tuple[CompiledJoinKey[pl.Expr], ...],
         named_aggs: dict[str, tuple[str, str]],
     ) -> PolarsBackendFrame:
         if not keys:
             raise ValueError("keys must be non-empty")
+        by_exprs: list[pl.Expr] = []
+        for i, k in enumerate(keys):
+            if k.column is not None:
+                by_exprs.append(pl.col(k.column))
+            elif k.expr is not None:
+                by_exprs.append(k.expr.alias(f"__pf_g{i}"))
+            else:
+                raise ValueError("CompiledJoinKey requires column or expr")
         agg_exprs: list[pl.Expr] = []
         for out_name, (op, col) in named_aggs.items():
             e = pl.col(col)
@@ -153,7 +161,7 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
             else:
                 raise ValueError(f"Unsupported agg op: {op!r}")
             agg_exprs.append(ex.alias(out_name))
-        return df.group_by(list(keys)).agg(agg_exprs)
+        return df.group_by(*by_exprs).agg(agg_exprs)
 
     def drop_nulls(
         self, df: PolarsBackendFrame, subset: tuple[str, ...] | None

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -137,9 +137,11 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
         self,
         df: BackendFrameT,
         *,
-        keys: tuple[str, ...],
+        keys: tuple[CompiledJoinKey[BackendExprT], ...],
         named_aggs: dict[str, tuple[str, str]],
-    ) -> BackendFrameT: ...
+    ) -> BackendFrameT:
+        """Group *df* by *keys* (column or compiled expression per slot), then apply *named_aggs*."""
+        ...
 
     @abstractmethod
     def drop_nulls(

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -54,7 +54,7 @@ from planframe.plan.nodes import (
     Unnest,
     WithColumn,
 )
-from planframe.schema.ir import Field, Schema
+from planframe.schema.ir import Field, Schema, collect_col_names_in_expr
 from planframe.schema.materialize import materialize_model
 from planframe.schema.source import schema_from_type
 
@@ -231,9 +231,10 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
             # prev is a GroupBy node
             if not isinstance(node.prev, GroupBy):
                 raise PlanFrameBackendError("Agg must follow GroupBy")
+            compiled_keys = self._compile_join_keys_tuple(node.prev.keys)
             return self._adapter.group_by_agg(
                 self._eval(node.prev.prev),
-                keys=node.prev.keys,
+                keys=compiled_keys,
                 named_aggs=node.named_aggs,
             )
         if isinstance(node, DropNulls):
@@ -648,16 +649,29 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
             _schema=self._schema,
         )
 
-    def group_by(self, *keys: str) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]:
+    def group_by(
+        self, *keys: str | Expr[Any]
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]:
         if not keys:
             raise PlanFrameBackendError("group_by requires at least one key")
-        self._schema.select(keys)  # validate
+        items = self._normalize_join_keys(tuple(keys))
+        fm = self._schema.field_map()
+        for k in items:
+            if isinstance(k, JoinKeyColumn):
+                self._schema.get(k.name)
+            else:
+                missing = collect_col_names_in_expr(k.expr).difference(fm.keys())
+                if missing:
+                    raise PlanFrameSchemaError(
+                        "group_by expression references unknown columns: "
+                        f"{sorted(missing)}"
+                    )
         return GroupedFrame(
             _data=self._data,
             _adapter=self._adapter,
             _plan=self._plan,
             _schema=self._schema,
-            _keys=tuple(keys),
+            _key_items=items,
         )
 
     def drop_nulls(self, *subset: str) -> Frame[SchemaT, BackendFrameT, BackendExprT]:

--- a/packages/planframe/planframe/frame.pyi
+++ b/packages/planframe/planframe/frame.pyi
@@ -324,7 +324,61 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         keep: Literal["first", "last"] | bool = ...,
         out_name: str = ...,
     ) -> Self: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString, __gk9: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(
+        self,
+        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString, __gk9: LiteralString, __gk10: LiteralString,
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
     def group_by(self, *keys: LiteralString) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    @overload
+    def group_by(self, *keys: LiteralString | Expr[Any]) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    def group_by(self, *keys: Any) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     def drop_nulls(self, *subset: LiteralString) -> Self: ...
     def fill_null(self, value: Any, *subset: LiteralString) -> Self: ...
     def melt(

--- a/packages/planframe/planframe/groupby.py
+++ b/packages/planframe/planframe/groupby.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import Any, Generic, Literal, TypeVar
 
 from planframe.backend.errors import PlanFrameSchemaError
-from planframe.plan.nodes import Agg, GroupBy, PlanNode
+from planframe.expr.api import infer_dtype
+from planframe.plan.nodes import Agg, GroupBy, JoinKeyColumn, JoinKeyExpr, PlanNode
 from planframe.schema.ir import Field, Schema
 
 SchemaT = TypeVar("SchemaT")
@@ -14,13 +15,13 @@ AggOp = Literal["count", "sum", "mean", "min", "max", "n_unique"]
 
 
 class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
-    __slots__ = ("_data", "_adapter", "_plan", "_schema", "_keys")
+    __slots__ = ("_data", "_adapter", "_plan", "_schema", "_key_items")
 
     _data: BackendFrameT
     _adapter: Any
     _plan: PlanNode
     _schema: Schema
-    _keys: tuple[str, ...]
+    _key_items: tuple[JoinKeyColumn | JoinKeyExpr, ...]
 
     def __init__(
         self,
@@ -29,19 +30,26 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         _adapter: Any,
         _plan: PlanNode,
         _schema: Schema,
-        _keys: tuple[str, ...],
+        _key_items: tuple[JoinKeyColumn | JoinKeyExpr, ...],
     ) -> None:
         self._data = _data
         self._adapter = _adapter
         self._plan = _plan
         self._schema = _schema
-        self._keys = _keys
+        self._key_items = _key_items
 
     def agg(self, **named_aggs: tuple[AggOp, str]) -> Any:
         if not named_aggs:
             raise PlanFrameSchemaError("agg requires at least one named aggregation")
         # Schema: keys + named aggs (types are conservative)
-        out_fields = [self._schema.get(k) for k in self._keys]
+        out_fields: list[Field] = []
+        for i, k in enumerate(self._key_items):
+            if isinstance(k, JoinKeyColumn):
+                out_fields.append(self._schema.get(k.name))
+            else:
+                out_fields.append(
+                    Field(name=f"__pf_g{i}", dtype=infer_dtype(k.expr))
+                )
         for out_name, (op, col) in named_aggs.items():
             self._schema.get(col)  # validate
             dtype: Any = object
@@ -49,7 +57,9 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
                 dtype = int
             out_fields.append(Field(name=out_name, dtype=dtype))
         schema2 = Schema(fields=tuple(out_fields))
-        plan2 = Agg(GroupBy(self._plan, keys=self._keys), named_aggs=dict(named_aggs))
+        plan2 = Agg(
+            GroupBy(self._plan, keys=self._key_items), named_aggs=dict(named_aggs)
+        )
         from planframe.frame import Frame  # avoid cycle
 
         return Frame(_data=self._data, _adapter=self._adapter, _plan=plan2, _schema=schema2)

--- a/packages/planframe/planframe/groupby.pyi
+++ b/packages/planframe/planframe/groupby.pyi
@@ -6,7 +6,7 @@ from typing_extensions import LiteralString
 
 from planframe.backend.adapter import BackendAdapter
 from planframe.frame import Frame
-from planframe.plan.nodes import PlanNode
+from planframe.plan.nodes import JoinKeyColumn, JoinKeyExpr, PlanNode
 from planframe.schema.ir import Schema
 
 BackendFrameT = TypeVar("BackendFrameT")
@@ -23,7 +23,7 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         _adapter: BackendAdapter[BackendFrameT, BackendExprT],
         _plan: PlanNode,
         _schema: Schema,
-        _keys: tuple[str, ...],
+        _key_items: tuple[JoinKeyColumn | JoinKeyExpr, ...],
     ) -> None: ...
     def agg(
         self, **named_aggs: tuple[AggOp, LiteralString]

--- a/packages/planframe/planframe/plan/nodes.py
+++ b/packages/planframe/planframe/plan/nodes.py
@@ -118,9 +118,23 @@ class Duplicated(PlanNode):
 
 
 @dataclass(frozen=True, slots=True)
+class JoinKeyColumn:
+    """Existing column name as a join or group-by key."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class JoinKeyExpr:
+    """Expression as a join or group-by key."""
+
+    expr: Expr[Any]
+
+
+@dataclass(frozen=True, slots=True)
 class GroupBy(PlanNode):
     prev: PlanNode
-    keys: tuple[str, ...]
+    keys: tuple[JoinKeyColumn | JoinKeyExpr, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,20 +163,6 @@ class Melt(PlanNode):
     value_vars: tuple[str, ...]
     variable_name: str
     value_name: str
-
-
-@dataclass(frozen=True, slots=True)
-class JoinKeyColumn:
-    """Join predicate uses this existing column name on one side."""
-
-    name: str
-
-
-@dataclass(frozen=True, slots=True)
-class JoinKeyExpr:
-    """Join predicate compares this expression to the paired key on the other side."""
-
-    expr: Expr[Any]
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/generate_typing_stubs.py
+++ b/scripts/generate_typing_stubs.py
@@ -194,8 +194,23 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a('        keep: Literal["first", "last"] | bool = ...,')
     a("        out_name: str = ...,")
     a("    ) -> Self: ...")
+    for n in range(1, max_arity + 1):
+        params = ", ".join([f"__gk{i}: LiteralString" for i in range(1, n + 1)])
+        a("    @overload")
+        a("    def group_by(")
+        a("        self,")
+        a(f"        {params},")
+        a("    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...")
+    a("    @overload")
     a(
         "    def group_by(self, *keys: LiteralString) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ..."
+    )
+    a("    @overload")
+    a(
+        "    def group_by(self, *keys: LiteralString | Expr[Any]) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ..."
+    )
+    a(
+        "    def group_by(self, *keys: Any) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ..."
     )
     a("    def drop_nulls(self, *subset: LiteralString) -> Self: ...")
     a("    def fill_null(self, value: Any, *subset: LiteralString) -> Self: ...")

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -254,17 +254,31 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
         self,
         df: list[dict[str, Any]],
         *,
-        keys: tuple[str, ...],
+        keys: tuple[CompiledJoinKey[object], ...],
         named_aggs: dict[str, tuple[str, str]],
     ) -> list[dict[str, Any]]:
         self.calls.append(("group_by_agg", (keys, dict(named_aggs))))
+        out_names = tuple(
+            k.column if k.column is not None else f"__pf_g{i}"
+            for i, k in enumerate(keys)
+        )
+
+        def part_key(row: dict[str, Any]) -> tuple[Any, ...]:
+            parts: list[Any] = []
+            for k in keys:
+                if k.column is not None:
+                    parts.append(row[k.column])
+                else:
+                    parts.append(_spy_sort_scalar_from_expr(row, k.expr))
+            return tuple(parts)
+
         groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
         for row in df:
-            k = tuple(row[x] for x in keys)
-            groups.setdefault(k, []).append(row)
+            pk = part_key(row)
+            groups.setdefault(pk, []).append(row)
         out: list[dict[str, Any]] = []
-        for k, rows in groups.items():
-            base = {keys[i]: k[i] for i in range(len(keys))}
+        for pk, rows in groups.items():
+            base = {out_names[i]: pk[i] for i in range(len(keys))}
             for out_name, (op, col_name) in named_aggs.items():
                 vals = [r[col_name] for r in rows]
                 if op == "count":
@@ -862,6 +876,48 @@ def test_join_asymmetric_keys_inner() -> None:
     assert collected == [{"user_id": 1, "x": 10, "y": 100}]
     assert adapter.calls[0][1][0] == (CompiledJoinKey(column="user_id", expr=None),)
     assert adapter.calls[0][1][1] == (CompiledJoinKey(column="id", expr=None),)
+
+
+def test_group_by_expression_key_spy() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class Row:
+        g: str
+        v: int
+
+    from planframe.expr import lower
+
+    pf = Frame.source(
+        [
+            {"g": "A", "v": 1},
+            {"g": "a", "v": 2},
+            {"g": "B", "v": 10},
+        ],
+        adapter=adapter,
+        schema=Row,
+    )
+    out = pf.group_by(lower(col("g"))).agg(n=("count", "v"), total=("sum", "v"))
+    collected = out.collect()
+    assert len(collected) == 2
+    by_g0 = {r["__pf_g0"]: r for r in collected}
+    assert by_g0["a"]["n"] == 2
+    assert by_g0["a"]["total"] == 3
+    assert by_g0["b"]["n"] == 1
+    assert by_g0["b"]["total"] == 10
+    gb_call = next(c for c in adapter.calls if c[0] == "group_by_agg")
+    keys = gb_call[1][0]
+    assert keys[0].column is None
+    assert keys[0].expr is not None
+
+
+def test_group_by_expr_rejects_unknown_column() -> None:
+    adapter = SpyAdapter()
+    from planframe.expr import lower
+
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
+    with pytest.raises(PlanFrameSchemaError):
+        pf.group_by(lower(col("nope")))
 
 
 def test_join_expression_keys_inner() -> None:

--- a/tests/test_polars_conformance.py
+++ b/tests/test_polars_conformance.py
@@ -321,6 +321,20 @@ def test_group_by_agg() -> None:
     assert collected["n"].to_list() == [2, 1]
 
 
+def test_group_by_expression_key_polars() -> None:
+    pf = User({"name": ["A", "a", "B"], "age": [1, 2, 10], "id": [1, 2, 3]})
+    out = (
+        pf.group_by(lower(col("name")))
+        .agg(n=("count", "age"), total=("sum", "age"))
+        .sort("__pf_g0")
+    )
+    collected = out.collect()
+    assert collected.columns == ["__pf_g0", "n", "total"]
+    assert collected["__pf_g0"].to_list() == ["a", "b"]
+    assert collected["n"].to_list() == [2, 1]
+    assert collected["total"].to_list() == [3, 10]
+
+
 def test_sort_descending() -> None:
     pf = User({"id": [2, 1, 3], "name": ["b", "a", "c"], "age": [20, 10, 30]})
     out = pf.sort("id", descending=True).collect()


### PR DESCRIPTION
## Summary
Implements [issue #11](https://github.com/eddiethedean/planframe/issues/11): `group_by` accepts column names or `Expr` keys, aligned with join/sort.

## Changes
- **IR**: `GroupBy.keys` is `tuple[JoinKeyColumn | JoinKeyExpr, ...]` (join key types reused; `JoinKeyColumn` / `JoinKeyExpr` live once above `GroupBy` in `nodes.py`).
- **API**: `Frame.group_by(*keys: str | Expr)` validates string keys against the schema and expression keys via `collect_col_names_in_expr`.
- **Schema**: Expression keys appear as `__pf_g0`, `__pf_g1`, … with dtypes from `infer_dtype`.
- **Execution**: `Agg` evaluation compiles keys with `_compile_join_keys_tuple`; `group_by_agg` takes `tuple[CompiledJoinKey, ...]`. Polars aliases compiled expr keys; Spy adapter matches that naming for tests.
- **Typing**: Regenerated `frame.pyi` (overload pattern like `sort`); `groupby.pyi` uses `_key_items`.

## Tests
- Spy: `lower(col("g"))` groups case-insensitively; unknown column in expr raises `PlanFrameSchemaError`.
- Polars: same shape and column names on collect.

Fixes #11