### PR TITLE
Agg: support expression aggregations (AggExpr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ df = out.collect()
   - **set-like**: `concat_vertical`
   - **dedupe**: `unique`, `duplicated`
   - **joins**: `join` (`on` / `left_on` / `right_on` may mix column names and `Expr` keys)
-  - **grouping**: `group_by(...).agg(...)` (keys may be column names or expressions; expression keys appear as `__pf_g0`, `__pf_g1`, … in the result schema)
+  - **grouping**: `group_by(...).agg(...)` (keys may be column names or expressions; expression keys appear as `__pf_g0`, `__pf_g1`, … in the result schema; aggregations may be `(op, column)` or `agg_sum(expr)` / `agg_mean(expr)` / … over any supported expression)
   - **core**: `with_column`, `cast`, `filter`, `sort` (keys may be column names and/or `Expr`; schema unchanged)
 - **Boundaries**:
   - `collect()` executes the accumulated plan using the adapter/backend

--- a/docs/guides/planframe/examples/rows_adapter_minimal.py
+++ b/docs/guides/planframe/examples/rows_adapter_minimal.py
@@ -111,7 +111,7 @@ class RowsAdapter(BaseAdapter[RowsFrame, Expr[object]]):
         df: RowsFrame,
         *,
         keys: tuple[CompiledJoinKey[Expr[object]], ...],
-        named_aggs: dict[str, tuple[str, str]],
+        named_aggs: dict[str, tuple[str, str] | Expr[object]],
     ) -> RowsFrame:
         raise NotImplementedError("RowsAdapter example does not implement group_by_agg")
 

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -131,7 +131,7 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
         df: PolarsBackendFrame,
         *,
         keys: tuple[CompiledJoinKey[pl.Expr], ...],
-        named_aggs: dict[str, tuple[str, str]],
+        named_aggs: dict[str, tuple[str, str] | pl.Expr],
     ) -> PolarsBackendFrame:
         if not keys:
             raise ValueError("keys must be non-empty")
@@ -144,23 +144,27 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
             else:
                 raise ValueError("CompiledJoinKey requires column or expr")
         agg_exprs: list[pl.Expr] = []
-        for out_name, (op, col) in named_aggs.items():
-            e = pl.col(col)
-            if op == "count":
-                ex = e.count()
-            elif op == "sum":
-                ex = e.sum()
-            elif op == "mean":
-                ex = e.mean()
-            elif op == "min":
-                ex = e.min()
-            elif op == "max":
-                ex = e.max()
-            elif op == "n_unique":
-                ex = e.n_unique()
+        for out_name, spec in named_aggs.items():
+            if isinstance(spec, tuple):
+                op, col = spec
+                e = pl.col(col)
+                if op == "count":
+                    ex = e.count()
+                elif op == "sum":
+                    ex = e.sum()
+                elif op == "mean":
+                    ex = e.mean()
+                elif op == "min":
+                    ex = e.min()
+                elif op == "max":
+                    ex = e.max()
+                elif op == "n_unique":
+                    ex = e.n_unique()
+                else:
+                    raise ValueError(f"Unsupported agg op: {op!r}")
+                agg_exprs.append(ex.alias(out_name))
             else:
-                raise ValueError(f"Unsupported agg op: {op!r}")
-            agg_exprs.append(ex.alias(out_name))
+                agg_exprs.append(spec.alias(out_name))
         return df.group_by(*by_exprs).agg(agg_exprs)
 
     def drop_nulls(

--- a/packages/planframe-polars/planframe_polars/compile_expr.py
+++ b/packages/planframe-polars/planframe_polars/compile_expr.py
@@ -8,6 +8,7 @@ from planframe.backend.errors import PlanFrameExpressionError
 from planframe.expr.api import (
     Abs,
     Add,
+    AggExpr,
     And,
     Between,
     Ceil,
@@ -175,5 +176,20 @@ def compile_expr(expr: Expr[Any]) -> pl.Expr:
         return compile_expr(expr.value).sqrt()
     if isinstance(expr, IsFinite):
         return compile_expr(expr.value).is_finite()
+    if isinstance(expr, AggExpr):
+        inner = compile_expr(expr.inner)
+        if expr.op == "count":
+            return inner.count()
+        if expr.op == "sum":
+            return inner.sum()
+        if expr.op == "mean":
+            return inner.mean()
+        if expr.op == "min":
+            return inner.min()
+        if expr.op == "max":
+            return inner.max()
+        if expr.op == "n_unique":
+            return inner.n_unique()
+        raise PlanFrameExpressionError(f"Unsupported aggregation op: {expr.op!r}")
 
     raise PlanFrameExpressionError(f"Unsupported expr node: {type(expr)!r}")

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -138,9 +138,13 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
         df: BackendFrameT,
         *,
         keys: tuple[CompiledJoinKey[BackendExprT], ...],
-        named_aggs: dict[str, tuple[str, str]],
+        named_aggs: dict[str, tuple[str, str] | BackendExprT],
     ) -> BackendFrameT:
-        """Group *df* by *keys* (column or compiled expression per slot), then apply *named_aggs*."""
+        """Group *df* by *keys*, then apply *named_aggs*.
+
+        Each aggregation is either ``(op, column_name)`` or a compiled backend expression
+        produced from :class:`planframe.expr.api.AggExpr` (already an aggregation expr).
+        """
         ...
 
     @abstractmethod

--- a/packages/planframe/planframe/expr/__init__.py
+++ b/packages/planframe/planframe/expr/__init__.py
@@ -1,7 +1,14 @@
 from planframe.expr.api import (
+    AggExpr,
     Expr,
     abs_,
     add,
+    agg_count,
+    agg_max,
+    agg_mean,
+    agg_min,
+    agg_n_unique,
+    agg_sum,
     and_,
     between,
     ceil,
@@ -49,8 +56,15 @@ from planframe.expr.api import (
 )
 
 __all__ = [
+    "AggExpr",
     "Expr",
     "add",
+    "agg_count",
+    "agg_max",
+    "agg_mean",
+    "agg_min",
+    "agg_n_unique",
+    "agg_sum",
     "abs_",
     "and_",
     "between",

--- a/packages/planframe/planframe/expr/api.py
+++ b/packages/planframe/planframe/expr/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from planframe.backend.errors import PlanFrameExpressionError
 
@@ -270,6 +270,17 @@ class IsFinite(Expr[bool]):
     value: Expr[object]
 
 
+AggOpLiteral = Literal["count", "sum", "mean", "min", "max", "n_unique"]
+
+
+@dataclass(frozen=True, slots=True)
+class AggExpr(Expr[object]):
+    """Apply an aggregation *op* to *inner* inside :meth:`~planframe.groupby.GroupedFrame.agg`."""
+
+    op: AggOpLiteral
+    inner: Expr[object]
+
+
 def col(name: str) -> Col[object]:
     return Col(name=name)
 
@@ -472,6 +483,30 @@ def is_finite(value: Expr[object]) -> IsFinite:
     return IsFinite(value=value)
 
 
+def agg_count(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="count", inner=inner)
+
+
+def agg_sum(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="sum", inner=inner)
+
+
+def agg_mean(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="mean", inner=inner)
+
+
+def agg_min(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="min", inner=inner)
+
+
+def agg_max(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="max", inner=inner)
+
+
+def agg_n_unique(inner: Expr[object]) -> AggExpr:
+    return AggExpr(op="n_unique", inner=inner)
+
+
 def _assert_bool(expr: Expr[object]) -> Expr[bool]:
     if isinstance(
         expr,
@@ -558,6 +593,12 @@ def infer_dtype(expr: Expr[Any]) -> Any:
     ):
         return object
     if isinstance(expr, (StrLen, DtYear, DtMonth, DtDay)):
+        return object
+    if isinstance(expr, AggExpr):
+        if expr.op in {"count", "n_unique"}:
+            return int
+        if expr.op == "mean":
+            return float
         return object
     if isinstance(expr, Col):
         return Any

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -138,6 +138,17 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
                 out.append(CompiledJoinKey(column=None, expr=self._compile(k.expr)))
         return tuple(out)
 
+    def _compile_named_aggs(
+        self, named_aggs: dict[str, tuple[str, str] | Expr[Any]]
+    ) -> dict[str, tuple[str, str] | BackendExprT]:
+        out: dict[str, tuple[str, str] | BackendExprT] = {}
+        for name, spec in named_aggs.items():
+            if isinstance(spec, tuple):
+                out[name] = spec
+            else:
+                out[name] = self._compile(spec)
+        return out
+
     def _normalize_join_keys(
         self, items: tuple[str | Expr[Any], ...]
     ) -> tuple[JoinKeyColumn | JoinKeyExpr, ...]:
@@ -232,10 +243,11 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
             if not isinstance(node.prev, GroupBy):
                 raise PlanFrameBackendError("Agg must follow GroupBy")
             compiled_keys = self._compile_join_keys_tuple(node.prev.keys)
+            compiled_aggs = self._compile_named_aggs(node.named_aggs)
             return self._adapter.group_by_agg(
                 self._eval(node.prev.prev),
                 keys=compiled_keys,
-                named_aggs=node.named_aggs,
+                named_aggs=compiled_aggs,
             )
         if isinstance(node, DropNulls):
             return self._adapter.drop_nulls(self._eval(node.prev), node.subset)

--- a/packages/planframe/planframe/groupby.py
+++ b/packages/planframe/planframe/groupby.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Any, Generic, Literal, TypeVar
 
 from planframe.backend.errors import PlanFrameSchemaError
-from planframe.expr.api import infer_dtype
+from planframe.expr.api import AggExpr, Expr, infer_dtype
 from planframe.plan.nodes import Agg, GroupBy, JoinKeyColumn, JoinKeyExpr, PlanNode
-from planframe.schema.ir import Field, Schema
+from planframe.schema.ir import Field, Schema, collect_col_names_in_expr
 
 SchemaT = TypeVar("SchemaT")
 BackendFrameT = TypeVar("BackendFrameT")
@@ -38,7 +38,7 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         self._schema = _schema
         self._key_items = _key_items
 
-    def agg(self, **named_aggs: tuple[AggOp, str]) -> Any:
+    def agg(self, **named_aggs: tuple[AggOp, str] | Expr[Any]) -> Any:
         if not named_aggs:
             raise PlanFrameSchemaError("agg requires at least one named aggregation")
         # Schema: keys + named aggs (types are conservative)
@@ -50,12 +50,28 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
                 out_fields.append(
                     Field(name=f"__pf_g{i}", dtype=infer_dtype(k.expr))
                 )
-        for out_name, (op, col) in named_aggs.items():
-            self._schema.get(col)  # validate
-            dtype: Any = object
-            if op in {"count", "n_unique"}:
-                dtype = int
-            out_fields.append(Field(name=out_name, dtype=dtype))
+        fm = self._schema.field_map()
+        for out_name, spec in named_aggs.items():
+            if isinstance(spec, tuple):
+                op, col = spec
+                self._schema.get(col)  # validate
+                dtype: Any = object
+                if op in {"count", "n_unique"}:
+                    dtype = int
+                out_fields.append(Field(name=out_name, dtype=dtype))
+            elif isinstance(spec, AggExpr):
+                missing = collect_col_names_in_expr(spec.inner).difference(fm.keys())
+                if missing:
+                    raise PlanFrameSchemaError(
+                        "aggregation expression references unknown columns: "
+                        f"{sorted(missing)}"
+                    )
+                out_fields.append(Field(name=out_name, dtype=infer_dtype(spec)))
+            else:
+                raise PlanFrameSchemaError(
+                    "agg expects (op, column_name) tuples or agg_sum/agg_mean/...(...) "
+                    f"over an expression, got {type(spec).__name__!r}"
+                )
         schema2 = Schema(fields=tuple(out_fields))
         plan2 = Agg(
             GroupBy(self._plan, keys=self._key_items), named_aggs=dict(named_aggs)

--- a/packages/planframe/planframe/groupby.pyi
+++ b/packages/planframe/planframe/groupby.pyi
@@ -5,6 +5,7 @@ from typing import Generic, Literal, TypeVar
 from typing_extensions import LiteralString
 
 from planframe.backend.adapter import BackendAdapter
+from planframe.expr.api import AggExpr
 from planframe.frame import Frame
 from planframe.plan.nodes import JoinKeyColumn, JoinKeyExpr, PlanNode
 from planframe.schema.ir import Schema
@@ -26,5 +27,5 @@ class GroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         _key_items: tuple[JoinKeyColumn | JoinKeyExpr, ...],
     ) -> None: ...
     def agg(
-        self, **named_aggs: tuple[AggOp, LiteralString]
+        self, **named_aggs: tuple[AggOp, LiteralString] | AggExpr
     ) -> Frame[SchemaT, BackendFrameT, BackendExprT]: ...

--- a/packages/planframe/planframe/plan/nodes.py
+++ b/packages/planframe/planframe/plan/nodes.py
@@ -140,7 +140,7 @@ class GroupBy(PlanNode):
 @dataclass(frozen=True, slots=True)
 class Agg(PlanNode):
     prev: PlanNode
-    named_aggs: dict[str, tuple[str, str]]
+    named_aggs: dict[str, tuple[str, str] | Expr[Any]]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/pyright/pass/group_by_agg.py
+++ b/tests/pyright/pass/group_by_agg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing_extensions import reveal_type
 
+from planframe.expr import agg_sum, col, truediv
 from planframe_polars import PolarsFrame
 
 
@@ -15,3 +16,6 @@ pf = User({"id": [1, 1], "age": [10, 20]})
 out = pf.group_by("id").agg(total=("sum", "age"), n=("count", "age"))
 df = out.collect()
 reveal_type(df)
+
+out2 = pf.group_by("id").agg(ratio=agg_sum(truediv(col("age"), col("id"))))
+reveal_type(out2.collect())

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -19,7 +19,7 @@ from planframe.backend.errors import (
     PlanFrameSchemaError,
 )
 from planframe.expr import Expr, add, col, eq, lit, mul, over
-from planframe.expr.api import Add, Col, Lit, Mul, StrLower, Sub
+from planframe.expr.api import Add, AggExpr, Col, Lit, Mul, StrLower, Sub, TrueDiv
 from planframe.frame import Frame
 from planframe.plan.join_options import JoinOptions
 from planframe.plan.nodes import Project
@@ -37,29 +37,42 @@ class UserPD(BaseModel):
     age: int
 
 
-def _spy_sort_scalar_from_expr(row: dict[str, Any], expr: Any) -> Any:
-    """Minimal PlanFrame expr evaluation for SpyAdapter.sort expression keys."""
+def _spy_row_expr(row: dict[str, Any], expr: Any) -> Any:
+    """Minimal PlanFrame expr evaluation for SpyAdapter (sort keys, group keys, agg inners)."""
 
     if isinstance(expr, Col):
         return row[expr.name]
     if isinstance(expr, Lit):
         return expr.value
     if isinstance(expr, Add):
-        return _spy_sort_scalar_from_expr(row, expr.left) + _spy_sort_scalar_from_expr(
-            row, expr.right
-        )
+        return _spy_row_expr(row, expr.left) + _spy_row_expr(row, expr.right)
     if isinstance(expr, Sub):
-        return _spy_sort_scalar_from_expr(row, expr.left) - _spy_sort_scalar_from_expr(
-            row, expr.right
-        )
+        return _spy_row_expr(row, expr.left) - _spy_row_expr(row, expr.right)
     if isinstance(expr, Mul):
-        return _spy_sort_scalar_from_expr(row, expr.left) * _spy_sort_scalar_from_expr(
-            row, expr.right
-        )
+        return _spy_row_expr(row, expr.left) * _spy_row_expr(row, expr.right)
+    if isinstance(expr, TrueDiv):
+        return _spy_row_expr(row, expr.left) / _spy_row_expr(row, expr.right)
     if isinstance(expr, StrLower):
-        v = _spy_sort_scalar_from_expr(row, expr.value)
+        v = _spy_row_expr(row, expr.value)
         return v.lower() if isinstance(v, str) else v
-    raise NotImplementedError(f"SpyAdapter.sort expr not supported: {type(expr).__name__}")
+    raise NotImplementedError(f"SpyAdapter expr not supported: {type(expr).__name__}")
+
+
+def _spy_agg_reduce(values: list[Any], op: str) -> Any:
+    non_null = [v for v in values if v is not None]
+    if op == "count":
+        return len(non_null)
+    if op == "sum":
+        return sum(non_null)
+    if op == "mean":
+        return sum(non_null) / len(non_null) if non_null else float("nan")
+    if op == "min":
+        return min(non_null) if non_null else None
+    if op == "max":
+        return max(non_null) if non_null else None
+    if op == "n_unique":
+        return len(set(non_null))
+    raise ValueError(f"unknown agg op: {op!r}")
 
 
 class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
@@ -172,8 +185,8 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
                 if k.column is not None:
                     va, vb = ra.get(k.column), rb.get(k.column)
                 else:
-                    va = _spy_sort_scalar_from_expr(ra, k.expr)
-                    vb = _spy_sort_scalar_from_expr(rb, k.expr)
+                    va = _spy_row_expr(ra, k.expr)
+                    vb = _spy_row_expr(rb, k.expr)
                 r = cmp_vals(va, vb, desc, nl)
                 if r != 0:
                     return r
@@ -255,7 +268,7 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
         df: list[dict[str, Any]],
         *,
         keys: tuple[CompiledJoinKey[object], ...],
-        named_aggs: dict[str, tuple[str, str]],
+        named_aggs: dict[str, tuple[str, str] | AggExpr],
     ) -> list[dict[str, Any]]:
         self.calls.append(("group_by_agg", (keys, dict(named_aggs))))
         out_names = tuple(
@@ -269,7 +282,7 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
                 if k.column is not None:
                     parts.append(row[k.column])
                 else:
-                    parts.append(_spy_sort_scalar_from_expr(row, k.expr))
+                    parts.append(_spy_row_expr(row, k.expr))
             return tuple(parts)
 
         groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
@@ -279,14 +292,21 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
         out: list[dict[str, Any]] = []
         for pk, rows in groups.items():
             base = {out_names[i]: pk[i] for i in range(len(keys))}
-            for out_name, (op, col_name) in named_aggs.items():
-                vals = [r[col_name] for r in rows]
-                if op == "count":
-                    base[out_name] = len(vals)
-                elif op == "sum":
-                    base[out_name] = sum(vals)  # type: ignore[arg-type]
+            for out_name, spec in named_aggs.items():
+                if isinstance(spec, tuple):
+                    op, col_name = spec
+                    vals = [r[col_name] for r in rows]
+                    if op == "count":
+                        base[out_name] = len(vals)
+                    elif op == "sum":
+                        base[out_name] = sum(vals)  # type: ignore[arg-type]
+                    else:
+                        base[out_name] = None
+                elif isinstance(spec, AggExpr):
+                    inner_vals = [_spy_row_expr(r, spec.inner) for r in rows]
+                    base[out_name] = _spy_agg_reduce(inner_vals, spec.op)
                 else:
-                    base[out_name] = None
+                    raise TypeError(f"unsupported named agg spec: {type(spec)!r}")
             out.append(dict(base))
         return out
 
@@ -361,7 +381,7 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
                 if k.column is not None:
                     parts.append(row[k.column])
                 else:
-                    parts.append(_spy_sort_scalar_from_expr(row, k.expr))
+                    parts.append(_spy_row_expr(row, k.expr))
             return tuple(parts)
 
         right_skip: set[str] = set()
@@ -918,6 +938,47 @@ def test_group_by_expr_rejects_unknown_column() -> None:
     pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
     with pytest.raises(PlanFrameSchemaError):
         pf.group_by(lower(col("nope")))
+
+
+def test_group_by_agg_expr_sum_ratio_spy() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class Row:
+        id: int
+        rev: int
+        clicks: int
+
+    from planframe.expr import agg_sum, truediv
+
+    pf = Frame.source(
+        [
+            {"id": 1, "rev": 10, "clicks": 2},
+            {"id": 1, "rev": 30, "clicks": 2},
+            {"id": 2, "rev": 100, "clicks": 5},
+        ],
+        adapter=adapter,
+        schema=Row,
+    )
+    out = (
+        pf.group_by("id")
+        .agg(
+            total_rev=("sum", "rev"),
+            rpc=agg_sum(truediv(col("rev"), col("clicks"))),
+        )
+        .sort("id")
+    )
+    rows = out.collect()
+    assert rows[0]["rpc"] == 20
+    assert rows[0]["total_rev"] == 40
+    assert rows[1]["rpc"] == 20
+
+
+def test_group_by_agg_rejects_non_agg_expression() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1, "age": 10}], adapter=adapter, schema=UserDC)
+    with pytest.raises(PlanFrameSchemaError, match="agg expects"):
+        pf.group_by("id").agg(x=col("age"))
 
 
 def test_join_expression_keys_inner() -> None:

--- a/tests/test_polars_conformance.py
+++ b/tests/test_polars_conformance.py
@@ -335,6 +335,15 @@ def test_group_by_expression_key_polars() -> None:
     assert collected["total"].to_list() == [3, 10]
 
 
+def test_group_by_agg_expression_polars() -> None:
+    from planframe.expr import agg_sum, truediv
+
+    pf = User({"id": [1, 1, 2], "age": [10, 20, 15], "name": ["a", "b", "c"]})
+    out = pf.group_by("id").agg(s=agg_sum(truediv(col("age"), col("id")))).sort("id")
+    collected = out.collect()
+    assert collected["s"].to_list() == [30.0, 7.5]
+
+
 def test_sort_descending() -> None:
     pf = User({"id": [2, 1, 3], "name": ["b", "a", "c"], "age": [20, 10, 30]})
     out = pf.sort("id", descending=True).collect()


### PR DESCRIPTION
## Summary
Closes [issue #12](https://github.com/eddiethedean/planframe/issues/12): `GroupedFrame.agg` accepts the existing `(op, column)` tuples **or** `AggExpr` wrappers (`agg_sum`, `agg_mean`, …) over any expression the IR and backend can compile.

## Design (Option B–style)
- **IR**: `Agg.named_aggs: dict[str, tuple[str, str] | Expr]` — only `AggExpr` is accepted as an expression value (plain `col(...)` etc. are rejected with a clear schema error).
- **New nodes**: `AggExpr(op, inner)` plus helpers `agg_count`, `agg_sum`, `agg_mean`, `agg_min`, `agg_max`, `agg_n_unique`.
- **Execution**: `Frame._compile_named_aggs` compiles `AggExpr` to backend expressions; Polars lowers via `compile_expr` (`inner.sum()`, etc.). Spy evaluates `inner` per row then reduces.

## Backward compatibility
Existing `agg(foo=("sum", "bar"))` call sites unchanged.

## Tests
- Spy: mixed tuple + `agg_sum(truediv(...))`.
- Polars: `agg_sum(truediv(col("age"), col("id")))`.
- Schema: rejects bare `col` as aggregation value.
- Pyright pass sample updated.

Fixes #12