### PR TITLE
Unnest: persist fields in plan node

### DIFF
--- a/docs/guides/planframe/examples/rows_adapter_minimal.py
+++ b/docs/guides/planframe/examples/rows_adapter_minimal.py
@@ -203,7 +203,7 @@ class RowsAdapter(BaseAdapter[RowsFrame, Expr[object]]):
     def explode(self, df: RowsFrame, column: str) -> RowsFrame:
         raise NotImplementedError
 
-    def unnest(self, df: RowsFrame, column: str) -> RowsFrame:
+    def unnest(self, df: RowsFrame, column: str, *, fields: tuple[str, ...]) -> RowsFrame:
         raise NotImplementedError
 
     def concat_horizontal(self, left: RowsFrame, right: RowsFrame) -> RowsFrame:

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -485,7 +485,11 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
     def explode(self, df: PolarsBackendFrame, column: str) -> PolarsBackendFrame:
         return df.explode(column)
 
-    def unnest(self, df: PolarsBackendFrame, column: str) -> PolarsBackendFrame:
+    def unnest(
+        self, df: PolarsBackendFrame, column: str, *, fields: tuple[str, ...]
+    ) -> PolarsBackendFrame:
+        # Polars can unnest without explicit field selection; PlanFrame schema determines
+        # which output columns are expected.
         return df.unnest(column)
 
     def drop_nulls_all(

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -305,7 +305,9 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
     def explode(self, df: BackendFrameT, column: str) -> BackendFrameT: ...
 
     @abstractmethod
-    def unnest(self, df: BackendFrameT, column: str) -> BackendFrameT: ...
+    def unnest(
+        self, df: BackendFrameT, column: str, *, fields: tuple[str, ...]
+    ) -> BackendFrameT: ...
 
     @abstractmethod
     def drop_nulls_all(

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -312,7 +312,7 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         if isinstance(node, Explode):
             return self._adapter.explode(self._eval(node.prev), node.column)
         if isinstance(node, Unnest):
-            return self._adapter.unnest(self._eval(node.prev), node.column)
+            return self._adapter.unnest(self._eval(node.prev), node.column, fields=node.fields)
         if isinstance(node, ConcatHorizontal):
             left_df = self._eval(node.prev)
             other_frame = node.other
@@ -908,7 +908,7 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         return Frame(
             _data=self._data,
             _adapter=self._adapter,
-            _plan=Unnest(self._plan, column=column),
+            _plan=Unnest(self._plan, column=column, fields=fields),
             _schema=schema2,
         )
 

--- a/packages/planframe/planframe/plan/nodes.py
+++ b/packages/planframe/planframe/plan/nodes.py
@@ -222,6 +222,7 @@ class Explode(PlanNode):
 class Unnest(PlanNode):
     prev: PlanNode
     column: str
+    fields: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -482,15 +482,19 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
                 out.append(r2)
         return out
 
-    def unnest(self, df: list[dict[str, Any]], column: str) -> list[dict[str, Any]]:
-        self.calls.append(("unnest", column))
+    def unnest(
+        self, df: list[dict[str, Any]], column: str, *, fields: tuple[str, ...]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(("unnest", (column, fields)))
         out: list[dict[str, Any]] = []
         for r in df:
             s = r.get(column) or {}
             r2 = dict(r)
             r2.pop(column, None)
             if isinstance(s, dict):
-                r2.update(s)
+                for k in fields:
+                    if k in s:
+                        r2[k] = s[k]
             out.append(r2)
         return out
 
@@ -1205,6 +1209,20 @@ def test_new_transforms_are_lazy() -> None:
     )
     assert adapter.calls == []
     _ = out.collect()
+
+
+def test_unnest_plan_node_carries_fields() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class S:
+        id: int
+        s: object
+
+    pf = Frame.source([{"id": 1, "s": {"a": 1, "b": 2}}], adapter=adapter, schema=S)
+    out = pf.unnest("s", fields=("a", "b")).collect()
+    assert out == [{"id": 1, "a": 1, "b": 2}]
+    assert ("unnest", ("s", ("a", "b"))) in adapter.calls
 
 
 def test_write_methods_execute_and_are_boundaries(tmp_path: Any) -> None:


### PR DESCRIPTION
## Summary
Implements [issue #13](https://github.com/eddiethedean/planframe/issues/13): the  plan node now carries the  tuple so adapters can execute  with explicit subfield names.

## Changes
- **IR**:  stores the requested struct fields.
- **Execution**:  records fields in the plan; evaluation calls .
- **Adapter contract**:  updated; Polars adapter accepts (and currently ignores) .
- **Tests**: Spy adapter now records  and only emits the requested subkeys; added regression test.

Fixes #13