### PR TITLE
Adapter compile_expr: optional schema context

### DIFF
--- a/docs/guides/planframe/examples/rows_adapter_minimal.py
+++ b/docs/guides/planframe/examples/rows_adapter_minimal.py
@@ -27,7 +27,7 @@ RowsFrame = list[dict[str, object]]
 class RowsAdapter(BaseAdapter[RowsFrame, Expr[object]]):
     name = "rows"
 
-    def compile_expr(self, expr: Expr[object]) -> Expr[object]:
+    def compile_expr(self, expr: Expr[object], *, schema: Any = None) -> Expr[object]:
         return expr
 
     def select(self, df: RowsFrame, columns: tuple[str, ...]) -> RowsFrame:

--- a/docs/planframe_backend_adapter_design.md
+++ b/docs/planframe_backend_adapter_design.md
@@ -121,7 +121,7 @@ class BackendAdapter(Protocol, Generic[BackendFrameT, BackendExprT]):
     ) -> BackendFrameT:
         ...
 
-    def compile_expr(self, expr: Any) -> BackendExprT:
+    def compile_expr(self, expr: Any, *, schema: Any | None = None) -> BackendExprT:
         ...
 
     def collect(self, df: BackendFrameT) -> BackendFrameT:
@@ -235,7 +235,7 @@ class PolarsAdapter:
     def filter(self, df: pl.DataFrame | pl.LazyFrame, predicate: pl.Expr):
         return df.filter(predicate)
 
-    def compile_expr(self, expr: Any) -> pl.Expr:
+    def compile_expr(self, expr: Any, *, schema: Any | None = None) -> pl.Expr:
         ...
 
     def collect(self, df: pl.DataFrame | pl.LazyFrame):
@@ -322,7 +322,7 @@ class PandasAdapter:
     def filter(self, df: pd.DataFrame, predicate: Any) -> pd.DataFrame:
         return df.loc[predicate].copy()
 
-    def compile_expr(self, expr: Any) -> Any:
+    def compile_expr(self, expr: Any, *, schema: Any | None = None) -> Any:
         ...
 
     def collect(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -121,7 +121,7 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
         mask = df.select(mask_expr.alias(out_name))[out_name]
         return pl.DataFrame({out_name: mask})
 
-    def compile_expr(self, expr: Any) -> pl.Expr:
+    def compile_expr(self, expr: Any, *, schema: Any = None) -> pl.Expr:
         if not isinstance(expr, Expr):
             raise TypeError(f"Expected PlanFrame Expr, got {type(expr)!r}")
         return compile_expr(expr)

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 from planframe.plan.join_options import JoinOptions
+from planframe.schema.ir import Schema
 
 BackendFrameT = TypeVar("BackendFrameT")
 BackendExprT = TypeVar("BackendExprT")
@@ -327,7 +328,7 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
     ) -> BackendFrameT: ...
 
     @abstractmethod
-    def compile_expr(self, expr: Any) -> BackendExprT: ...
+    def compile_expr(self, expr: Any, *, schema: Schema | None = None) -> BackendExprT: ...
 
     @abstractmethod
     def collect(self, df: BackendFrameT) -> BackendFrameT: ...

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -121,7 +121,7 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
 
     def _compile(self, expr: Any) -> BackendExprT:
         try:
-            return self._adapter.compile_expr(expr)
+            return self._adapter.compile_expr(expr, schema=self._schema)
         except Exception as e:  # noqa: BLE001
             raise PlanFrameBackendError(
                 f"Failed to compile expression for backend {self._adapter.name}"

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -148,8 +148,8 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
         self.calls.append(("filter", predicate))
         return df[:1]
 
-    def compile_expr(self, expr: Any) -> object:
-        self.calls.append(("compile_expr", type(expr).__name__))
+    def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
+        self.calls.append(("compile_expr", (type(expr).__name__, schema is not None)))
         return expr
 
     def sort(
@@ -1241,10 +1241,10 @@ def test_write_methods_execute_and_are_boundaries(tmp_path: Any) -> None:
 
 def test_backend_compile_expr_type_guard() -> None:
     class StrictAdapter(SpyAdapter):
-        def compile_expr(self, expr: Any) -> object:
+        def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
             if not isinstance(expr, Expr):
                 raise TypeError("Expected Expr")
-            return super().compile_expr(expr)
+            return super().compile_expr(expr, schema=schema)
 
     adapter = StrictAdapter()
     pf = Frame.source([{"id": 1, "age": 2}], adapter=adapter, schema=UserDC)


### PR DESCRIPTION
## Summary
Implements [issue #14](https://github.com/eddiethedean/planframe/issues/14): adapters can optionally receive schema context when lowering expressions.

## Changes
- **Adapter contract**: .
- **Core**:  passes the current  () when compiling expressions used by plan nodes.
- **Backends/examples/tests**: Polars adapter and the minimal rows adapter example accept the new kwarg; Spy/Strict adapters updated.
- **Docs**: adapter design doc updated to show the new signature.

Backwards compatibility: adapters may ignore .

Fixes #14