### PR TITLE
Async materialization (acollect, adapter hooks)

### DIFF
--- a/docs/planframe_backend_adapter_design.md
+++ b/docs/planframe_backend_adapter_design.md
@@ -126,12 +126,36 @@ class BackendAdapter(Protocol, Generic[BackendFrameT, BackendExprT]):
 
     def collect(self, df: BackendFrameT) -> BackendFrameT:
         ...
+
+    async def acollect(self, df: BackendFrameT) -> BackendFrameT:
+        ...
+
+    async def ato_dicts(self, df: BackendFrameT) -> list[dict[str, object]]:
+        ...
+
+    async def ato_dict(self, df: BackendFrameT) -> dict[str, list[object]]:
+        ...
 ```
 
 ### Notes
 - `compile_expr` converts PlanFrame expression IR into backend-native expression objects.
 - `collect` may be a no-op for eager backends like pandas.
 - `BackendFrameT` may be a DataFrame or LazyFrame depending on backend strategy.
+
+### Async materialization ([issue #15](https://github.com/eddiethedean/planframe/issues/15))
+
+PlanFrame stays **synchronous for lazy chaining**: building a `Frame` only updates the logical plan. **Materialization** can be sync or async:
+
+| API | Role |
+| --- | --- |
+| `Frame.collect()`, `Frame.to_dicts()`, `Frame.to_dict()` | Blocking; call from sync code or from `asyncio.to_thread`. |
+| `Frame.acollect()`, `Frame.ato_dicts()`, `Frame.ato_dict()` | Awaitable; use in async code. |
+
+`BaseAdapter` provides default `acollect` / `ato_dicts` / `ato_dict` that run the matching sync method in `asyncio.to_thread`, so existing adapters work without changes. Backends backed by asyncio-only clients should **override** `acollect` (and optionally `ato_dicts` / `ato_dict`) to await their native I/O instead of blocking a thread.
+
+**Plan evaluation** (`_eval` / applying select/filter/… to the plan) remains synchronous on the event-loop thread; only adapter execution at the boundary is async. Async backends should keep plan translation fast and perform I/O inside `acollect` (or related hooks).
+
+**Thread safety:** default async methods may invoke the adapter from multiple thread-pool workers concurrently if several `acollect` tasks run in parallel. Adapters that mutate shared connection state should document constraints or serialize; thread-local or per-task clients are typical.
 
 ---
 
@@ -167,7 +191,7 @@ Each method:
 3. returns a new immutable `Frame`
 
 Execution is deferred:
-- adapter methods like `select(...)` / `filter(...)` are applied when the plan is evaluated (typically inside `collect()`), not during chaining.
+- adapter methods like `select(...)` / `filter(...)` are applied when the plan is evaluated (typically inside `collect()` / `acollect()`), not during chaining.
 
 ---
 

--- a/packages/planframe/README.md
+++ b/packages/planframe/README.md
@@ -11,6 +11,8 @@ Core package for PlanFrame (typed planning layer). Import as `planframe`.
 ### Note on backends
 `planframe` is backend-agnostic. It does not execute anything until `collect()` (even for eager backends). To execute plans you need an adapter package (e.g. `planframe-polars`).
 
+For async stacks, `Frame.acollect()`, `Frame.ato_dicts()`, and `Frame.ato_dict()` await adapter hooks (`BaseAdapter.acollect` and friends); defaults run sync methods in a thread pool. See `docs/planframe_backend_adapter_design.md`.
+
 ### Typing
 PlanFrame includes `py.typed` plus generated stubs (notably `planframe/frame.pyi`) to improve static typing in editors and Pyright.
 

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
@@ -338,6 +339,28 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
 
     @abstractmethod
     def to_dict(self, df: BackendFrameT) -> dict[str, list[object]]: ...
+
+    async def acollect(self, df: BackendFrameT) -> BackendFrameT:
+        """Materialize *df* asynchronously.
+
+        Default: run :meth:`collect` in a worker thread via :func:`asyncio.to_thread`
+        so synchronous backends do not block the event loop.
+
+        Async-native backends (HTTP drivers, asyncio clients) should override this
+        instead of blocking in :meth:`collect`.
+        """
+
+        return await asyncio.to_thread(self.collect, df)
+
+    async def ato_dicts(self, df: BackendFrameT) -> list[dict[str, object]]:
+        """Like :meth:`to_dicts`, but awaitable. Default uses :func:`asyncio.to_thread`."""
+
+        return await asyncio.to_thread(self.to_dicts, df)
+
+    async def ato_dict(self, df: BackendFrameT) -> dict[str, list[object]]:
+        """Like :meth:`to_dict`, but awaitable. Default uses :func:`asyncio.to_thread`."""
+
+        return await asyncio.to_thread(self.to_dict, df)
 
 
 # Backwards-compatible name for older imports.

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -975,6 +975,32 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
                 f"Backend collect(kind={kind!r}) failed for {self._adapter.name}"
             ) from e
 
+    async def acollect(
+        self,
+        *,
+        kind: Literal["dataclass", "pydantic"] | None = None,
+        name: str = "Row",
+    ) -> BackendFrameT | list[Any]:
+        try:
+            planned = self._eval(self._plan)
+            out = await self._adapter.acollect(planned)
+        except Exception as e:  # noqa: BLE001
+            raise PlanFrameExecutionError(
+                f"Backend acollect failed for {self._adapter.name}"
+            ) from e
+
+        if kind is None:
+            return out
+
+        Model = materialize_model(name=name, schema=self._schema, kind=kind)
+        try:
+            rows = self._adapter.to_dicts(out)
+            return [Model(**r) for r in rows]
+        except Exception as e:  # noqa: BLE001
+            raise PlanFrameExecutionError(
+                f"Backend acollect(kind={kind!r}) failed for {self._adapter.name}"
+            ) from e
+
     def to_dicts(self) -> list[dict[str, object]]:
         try:
             planned = self._eval(self._plan)
@@ -990,6 +1016,24 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
             return self._adapter.to_dict(planned)
         except Exception as e:  # noqa: BLE001
             raise PlanFrameExecutionError(f"Backend to_dict failed for {self._adapter.name}") from e
+
+    async def ato_dicts(self) -> list[dict[str, object]]:
+        try:
+            planned = self._eval(self._plan)
+            return await self._adapter.ato_dicts(planned)
+        except Exception as e:  # noqa: BLE001
+            raise PlanFrameExecutionError(
+                f"Backend ato_dicts failed for {self._adapter.name}"
+            ) from e
+
+    async def ato_dict(self) -> dict[str, list[object]]:
+        try:
+            planned = self._eval(self._plan)
+            return await self._adapter.ato_dict(planned)
+        except Exception as e:  # noqa: BLE001
+            raise PlanFrameExecutionError(
+                f"Backend ato_dict failed for {self._adapter.name}"
+            ) from e
 
     def write_parquet(
         self,

--- a/packages/planframe/planframe/frame.pyi
+++ b/packages/planframe/planframe/frame.pyi
@@ -19,7 +19,6 @@ BackendExprT = TypeVar("BackendExprT")
 OtherSchemaT = TypeVar("OtherSchemaT")
 T = TypeVar("T")
 
-
 class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
     _data: BackendFrameT
     _adapter: BackendAdapter[BackendFrameT, BackendExprT]
@@ -33,7 +32,6 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         _plan: PlanNode,
         _schema: Schema,
     ) -> None: ...
-
     @classmethod
     def source(
         cls,
@@ -42,7 +40,6 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         adapter: BackendAdapter[BackendFrameT, BackendExprT],
         schema: type[SchemaT],
     ) -> Self: ...
-
     def schema(self) -> Schema: ...
     def plan(self) -> PlanNode: ...
 
@@ -55,143 +52,517 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
     @overload
     def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString) -> Self: ...
+    def select(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+    ) -> Self: ...
     @overload
-    def select(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString) -> Self: ...
+    def select(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+    ) -> Self: ...
     @overload
     def select(self, *columns: LiteralString) -> Self: ...
     @overload
     def select(self, *columns: LiteralString | tuple[str, Expr[Any]]) -> Self: ...
     def select(self, *columns: Any) -> Self: ...
-
     def select_prefix(self, prefix: str) -> Self: ...
     def select_suffix(self, suffix: str) -> Self: ...
     def select_regex(self, pattern: str) -> Self: ...
-
     @overload
     def select_exclude(self, __c1: LiteralString) -> Self: ...
     @overload
     def select_exclude(self, __c1: LiteralString, __c2: LiteralString) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString) -> Self: ...
+    def select_exclude(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString) -> Self: ...
+    def select_exclude(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_exclude(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString) -> Self: ...
+    def select_exclude(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+    ) -> Self: ...
     def select_exclude(self, *columns: LiteralString) -> Self: ...
-
     @overload
     def drop(self, __c1: LiteralString, *, strict: bool = True) -> Self: ...
     @overload
     def drop(self, __c1: LiteralString, __c2: LiteralString, *, strict: bool = True) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, *, strict: bool = True
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     @overload
-    def drop(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString, *, strict: bool = True) -> Self: ...
+    def drop(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+        *,
+        strict: bool = True,
+    ) -> Self: ...
     def drop(self, *columns: LiteralString, strict: bool = True) -> Self: ...
-
     def drop_prefix(self, prefix: str) -> Self: ...
     def drop_suffix(self, suffix: str) -> Self: ...
     def drop_regex(self, pattern: str) -> Self: ...
-
     @overload
     def reorder_columns(self, __c1: LiteralString) -> Self: ...
     @overload
     def reorder_columns(self, __c1: LiteralString, __c2: LiteralString) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString) -> Self: ...
+    def reorder_columns(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString) -> Self: ...
+    def reorder_columns(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+    ) -> Self: ...
     @overload
-    def reorder_columns(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString) -> Self: ...
+    def reorder_columns(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+    ) -> Self: ...
     def reorder_columns(self, *columns: LiteralString) -> Self: ...
-
     @overload
     def select_first(self, __c1: LiteralString) -> Self: ...
     @overload
     def select_first(self, __c1: LiteralString, __c2: LiteralString) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString) -> Self: ...
+    def select_first(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString) -> Self: ...
+    def select_first(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_first(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString) -> Self: ...
+    def select_first(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+    ) -> Self: ...
     def select_first(self, *columns: LiteralString) -> Self: ...
-
     @overload
     def select_last(self, __c1: LiteralString) -> Self: ...
     @overload
     def select_last(self, __c1: LiteralString, __c2: LiteralString) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString) -> Self: ...
+    def select_last(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString) -> Self: ...
+    def select_last(
+        self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+    ) -> Self: ...
     @overload
-    def select_last(self, __c1: LiteralString, __c2: LiteralString, __c3: LiteralString, __c4: LiteralString, __c5: LiteralString, __c6: LiteralString, __c7: LiteralString, __c8: LiteralString, __c9: LiteralString, __c10: LiteralString) -> Self: ...
+    def select_last(
+        self,
+        __c1: LiteralString,
+        __c2: LiteralString,
+        __c3: LiteralString,
+        __c4: LiteralString,
+        __c5: LiteralString,
+        __c6: LiteralString,
+        __c7: LiteralString,
+        __c8: LiteralString,
+        __c9: LiteralString,
+        __c10: LiteralString,
+    ) -> Self: ...
     def select_last(self, *columns: LiteralString) -> Self: ...
-
     def move(
         self,
         column: LiteralString,
@@ -199,19 +570,15 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         before: LiteralString | None = ...,
         after: LiteralString | None = ...,
     ) -> Self: ...
-
     def rename(self, *, strict: bool = ..., **mapping: str) -> Self: ...
-
     def rename_prefix(self, prefix: str, *subset: LiteralString) -> Self: ...
     def rename_suffix(self, suffix: str, *subset: LiteralString) -> Self: ...
     def rename_replace(self, old: str, new: str, *subset: LiteralString) -> Self: ...
-
     def with_column(
         self,
         name: LiteralString,
         expr: Expr[T],
     ) -> Self: ...
-
     @overload
     def cast(self, name: LiteralString, dtype: type[T]) -> Self: ...
     @overload
@@ -227,63 +594,108 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString, __k6: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
+        __k6: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString, __k6: LiteralString, __k7: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
+        __k6: LiteralString,
+        __k7: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString, __k6: LiteralString, __k7: LiteralString, __k8: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
+        __k6: LiteralString,
+        __k7: LiteralString,
+        __k8: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString, __k6: LiteralString, __k7: LiteralString, __k8: LiteralString, __k9: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
+        __k6: LiteralString,
+        __k7: LiteralString,
+        __k8: LiteralString,
+        __k9: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
     @overload
     def sort(
         self,
-        __k1: LiteralString, __k2: LiteralString, __k3: LiteralString, __k4: LiteralString, __k5: LiteralString, __k6: LiteralString, __k7: LiteralString, __k8: LiteralString, __k9: LiteralString, __k10: LiteralString,
+        __k1: LiteralString,
+        __k2: LiteralString,
+        __k3: LiteralString,
+        __k4: LiteralString,
+        __k5: LiteralString,
+        __k6: LiteralString,
+        __k7: LiteralString,
+        __k8: LiteralString,
+        __k9: LiteralString,
+        __k10: LiteralString,
         descending: bool | Sequence[bool] = ...,
         nulls_last: bool | Sequence[bool] = ...,
     ) -> Self: ...
@@ -333,52 +745,101 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
+        __gk6: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
+        __gk6: LiteralString,
+        __gk7: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
+        __gk6: LiteralString,
+        __gk7: LiteralString,
+        __gk8: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString, __gk9: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
+        __gk6: LiteralString,
+        __gk7: LiteralString,
+        __gk8: LiteralString,
+        __gk9: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def group_by(
         self,
-        __gk1: LiteralString, __gk2: LiteralString, __gk3: LiteralString, __gk4: LiteralString, __gk5: LiteralString, __gk6: LiteralString, __gk7: LiteralString, __gk8: LiteralString, __gk9: LiteralString, __gk10: LiteralString,
+        __gk1: LiteralString,
+        __gk2: LiteralString,
+        __gk3: LiteralString,
+        __gk4: LiteralString,
+        __gk5: LiteralString,
+        __gk6: LiteralString,
+        __gk7: LiteralString,
+        __gk8: LiteralString,
+        __gk9: LiteralString,
+        __gk10: LiteralString,
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
-    def group_by(self, *keys: LiteralString) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    def group_by(
+        self, *keys: LiteralString
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
-    def group_by(self, *keys: LiteralString | Expr[Any]) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    def group_by(
+        self, *keys: LiteralString | Expr[Any]
+    ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     def group_by(self, *keys: Any) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     def drop_nulls(self, *subset: LiteralString) -> Self: ...
     def fill_null(self, value: Any, *subset: LiteralString) -> Self: ...
@@ -390,7 +851,6 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         variable_name: str = ...,
         value_name: str = ...,
     ) -> Self: ...
-
     def slice(self, offset: int, length: int | None = ...) -> Self: ...
     def limit(self, n: int) -> Self: ...
     def head(self, n: int) -> Self: ...
@@ -420,7 +880,6 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         shuffle: bool = ...,
         seed: int | None = ...,
     ) -> Self: ...
-
     @overload
     def join(
         self,
@@ -569,11 +1028,18 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
     ) -> Frame[Any, BackendFrameT, BackendExprT]: ...
     @overload
     def collect(self) -> BackendFrameT: ...
-
     @overload
     def collect(self, *, kind: Literal["dataclass", "pydantic"], name: str = ...) -> list[Any]: ...
+    @overload
+    async def acollect(self) -> BackendFrameT: ...
+    @overload
+    async def acollect(
+        self, *, kind: Literal["dataclass", "pydantic"], name: str = ...
+    ) -> list[Any]: ...
     def to_dicts(self) -> list[dict[str, object]]: ...
     def to_dict(self) -> dict[str, list[object]]: ...
+    async def ato_dicts(self) -> list[dict[str, object]]: ...
+    async def ato_dict(self) -> dict[str, list[object]]: ...
     def write_parquet(
         self,
         path: str,
@@ -622,7 +1088,6 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         compression: Literal["uncompressed", "snappy", "deflate"] = ...,
         name: str = ...,
     ) -> None: ...
-
     def materialize_model(
         self,
         name: str,

--- a/packages/planframe/planframe/typing/_schema_types.pyi
+++ b/packages/planframe/planframe/typing/_schema_types.pyi
@@ -5,5 +5,4 @@ from typing import Generic, TypeVar
 LeftSchemaT = TypeVar("LeftSchemaT")
 RightSchemaT = TypeVar("RightSchemaT")
 
-class JoinedSchema(Generic[LeftSchemaT, RightSchemaT]):
-    ...
+class JoinedSchema(Generic[LeftSchemaT, RightSchemaT]): ...

--- a/scripts/generate_typing_stubs.py
+++ b/scripts/generate_typing_stubs.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
 import argparse
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ruff_format_pyi(path: Path, content: str) -> str:
+    """Match `ruff format` so ``ruff format --check`` passes on generated stubs."""
+
+    stdin_fn = f"--stdin-filename={path.relative_to(REPO_ROOT)}"
+    ruff_exe = shutil.which("ruff")
+    cmd = (
+        [ruff_exe, "format", "-", stdin_fn]
+        if ruff_exe
+        else [sys.executable, "-m", "ruff", "format", "-", stdin_fn]
+    )
+    proc = subprocess.run(
+        cmd,
+        input=content,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr or "ruff format failed")
+    return proc.stdout
 
 
 def _write_if_changed(path: Path, content: str) -> None:
@@ -346,8 +372,17 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a(
         '    def collect(self, *, kind: Literal["dataclass", "pydantic"], name: str = ...) -> list[Any]: ...'
     )
+    a("    @overload")
+    a("    async def acollect(self) -> BackendFrameT: ...")
+    a("")
+    a("    @overload")
+    a(
+        '    async def acollect(self, *, kind: Literal["dataclass", "pydantic"], name: str = ...) -> list[Any]: ...'
+    )
     a("    def to_dicts(self) -> list[dict[str, object]]: ...")
     a("    def to_dict(self) -> dict[str, list[object]]: ...")
+    a("    async def ato_dicts(self) -> list[dict[str, object]]: ...")
+    a("    async def ato_dict(self) -> dict[str, list[object]]: ...")
     a("    def write_parquet(")
     a("        self,")
     a("        path: str,")
@@ -436,11 +471,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     frame_pyi_path = REPO_ROOT / "packages" / "planframe" / "planframe" / "frame.pyi"
-    frame_pyi = _render_frame_pyi(max_arity=args.max_arity)
+    frame_pyi = _ruff_format_pyi(frame_pyi_path, _render_frame_pyi(max_arity=args.max_arity))
     schema_types_pyi_path = (
         REPO_ROOT / "packages" / "planframe" / "planframe" / "typing" / "_schema_types.pyi"
     )
-    schema_types_pyi = _render_schema_types_pyi()
+    schema_types_pyi = _ruff_format_pyi(schema_types_pyi_path, _render_schema_types_pyi())
 
     if args.check:
         changed: list[str] = []

--- a/tests/test_async_materialize.py
+++ b/tests/test_async_materialize.py
@@ -1,0 +1,108 @@
+"""Async materialization on Frame and BaseAdapter (issue #15)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from test_core_lazy_and_schema import SpyAdapter, UserDC
+
+from planframe.expr import col, eq, lit
+from planframe.frame import Frame
+
+
+class AsyncSpyAdapter(SpyAdapter):
+    """Spy that records ``acollect`` and yields before delegating to sync collect."""
+
+    async def acollect(self, df: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        self.calls.append(("acollect", None))
+        await asyncio.sleep(0)
+        return self.collect(df)
+
+
+def test_acollect_default_adapter_matches_collect() -> None:
+    async def run() -> None:
+        adapter = SpyAdapter()
+        data = [{"id": 1, "age": 2}]
+        pf = Frame.source(data, adapter=adapter, schema=UserDC)
+        out = await pf.select("id").acollect()
+        sync_out = pf.select("id").collect()
+        assert out == sync_out == [{"id": 1}]
+        assert "acollect" not in [c[0] for c in adapter.calls]
+
+    asyncio.run(run())
+
+
+def test_acollect_async_adapter_path() -> None:
+    adapter = AsyncSpyAdapter()
+    data = [{"id": 1, "age": 2}, {"id": 2, "age": 3}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    async def run() -> None:
+        out = await pf.select("id", "age").filter(eq(col("id"), lit(1))).acollect()
+        assert out == [{"id": 1, "age": 2}]
+        names = [c[0] for c in adapter.calls]
+        assert "acollect" in names
+        assert names[-1] == "collect"
+
+    asyncio.run(run())
+
+
+def test_ato_dicts_matches_to_dicts() -> None:
+    adapter = SpyAdapter()
+    data = [{"id": 1, "age": 2}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    async def run() -> None:
+        a = await pf.ato_dicts()
+        b = pf.to_dicts()
+        assert a == b
+
+    asyncio.run(run())
+
+
+def test_ato_dict_matches_to_dict() -> None:
+    adapter = SpyAdapter()
+    data = [{"id": 1, "age": 2}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    async def run() -> None:
+        a = await pf.ato_dict()
+        b = pf.to_dict()
+        assert a == b
+
+    asyncio.run(run())
+
+
+def test_acollect_kind_dataclass() -> None:
+    adapter = SpyAdapter()
+    data = [{"id": 1, "age": 2}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    async def run() -> None:
+        rows = await pf.acollect(kind="dataclass", name="UserRow")
+        assert len(rows) == 1
+        row = rows[0]
+        assert type(row).__name__ == "UserRow"
+        assert row.id == 1 and row.age == 2
+
+    asyncio.run(run())
+
+
+def test_acollect_native_async_skips_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Async adapter override runs on the event loop; it must not call ``asyncio.to_thread``."""
+
+    async def boom(*_a: object, **_k: object) -> object:
+        raise AssertionError("AsyncSpyAdapter.acollect must not use asyncio.to_thread")
+
+    monkeypatch.setattr(asyncio, "to_thread", boom)
+    adapter = AsyncSpyAdapter()
+    data = [{"id": 1, "age": 2}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    async def run() -> None:
+        out = await pf.acollect()
+        assert out == data
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
Implements [issue #15](https://github.com/eddiethedean/planframe/issues/15): first-class async materialization on `Frame` and optional async hooks on `BaseAdapter`.

## Changes
- **`BaseAdapter`**: `acollect`, `ato_dicts`, `ato_dict` with defaults that use `asyncio.to_thread` around the sync methods.
- **`Frame`**: `acollect` (including `kind=` dataclass/Pydantic), `ato_dicts`, `ato_dict`.
- **Docs**: sync vs async, thread-safety, plan eval stays sync; design doc protocol snippet + README pointer.
- **Tests**: `AsyncSpyAdapter`, parity with sync APIs, monkeypatch ensures overrides do not rely on `to_thread`.
- **Stubs**: regenerated; stub generator now runs Ruff on generated `.pyi` so `ruff format --check` and `--check` stay aligned (uses `ruff` on PATH when `python -m ruff` is unavailable).

Fixes #15