### PR TITLE
fix: extend join stubs beyond five keys

### DIFF
--- a/packages/planframe/planframe/frame.pyi
+++ b/packages/planframe/planframe/frame.pyi
@@ -958,6 +958,96 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         self,
         other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
         *,
+        on: tuple[
+            LiteralString, LiteralString, LiteralString, LiteralString, LiteralString, LiteralString
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
         left_on: tuple[LiteralString],
         right_on: tuple[LiteralString],
         how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
@@ -1004,6 +1094,141 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         *,
         left_on: tuple[LiteralString, LiteralString, LiteralString, LiteralString, LiteralString],
         right_on: tuple[LiteralString, LiteralString, LiteralString, LiteralString, LiteralString],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        left_on: tuple[
+            LiteralString, LiteralString, LiteralString, LiteralString, LiteralString, LiteralString
+        ],
+        right_on: tuple[
+            LiteralString, LiteralString, LiteralString, LiteralString, LiteralString, LiteralString
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        left_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        right_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        left_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        right_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        left_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        right_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
+        suffix: str = ...,
+        options: JoinOptions | None = ...,
+    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...
+    @overload
+    def join(
+        self,
+        other: Frame[OtherSchemaT, BackendFrameT, BackendExprT],
+        *,
+        left_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
+        right_on: tuple[
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+            LiteralString,
+        ],
         how: Literal["inner", "left", "right", "full", "semi", "anti"] = ...,
         suffix: str = ...,
         options: JoinOptions | None = ...,

--- a/scripts/generate_typing_stubs.py
+++ b/scripts/generate_typing_stubs.py
@@ -322,7 +322,7 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a("        suffix: str = ...,")
     a("        options: JoinOptions | None = ...,")
     a("    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...")
-    for n in range(2, 6):
+    for n in range(2, max_arity + 1):
         on_tuple = ", ".join(["LiteralString"] * n)
         a("    @overload")
         a("    def join(")
@@ -334,7 +334,7 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
         a("        suffix: str = ...,")
         a("        options: JoinOptions | None = ...,")
         a("    ) -> Frame[JoinedSchema[SchemaT, OtherSchemaT], BackendFrameT, BackendExprT]: ...")
-    for n in range(1, 6):
+    for n in range(1, max_arity + 1):
         lr = ", ".join(["LiteralString"] * n)
         a("    @overload")
         a("    def join(")

--- a/tests/pyright/pass/join_many_keys.py
+++ b/tests/pyright/pass/join_many_keys.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from planframe_polars import PolarsFrame
+
+
+class Left(PolarsFrame):
+    k1: int
+    k2: int
+    k3: int
+    k4: int
+    k5: int
+    k6: int
+
+
+class Right(PolarsFrame):
+    k1: int
+    k2: int
+    k3: int
+    k4: int
+    k5: int
+    k6: int
+
+
+left = Left({"k1": [1], "k2": [1], "k3": [1], "k4": [1], "k5": [1], "k6": [1]})
+right = Right({"k1": [1], "k2": [1], "k3": [1], "k4": [1], "k5": [1], "k6": [1]})
+
+_ = left.join(right, on=("k1", "k2", "k3", "k4", "k5", "k6"))


### PR DESCRIPTION
Fixes #18

## Summary
- Extend generated `Frame.join(...)` overloads for `on=` and `left_on`/`right_on` from 5 keys up to the stub generator `max_arity` (currently 10).
- Regenerate `packages/planframe/planframe/frame.pyi`.
- Add a Pyright pass fixture that joins on 6 keys without `cast(Any, ...)`.

## Test plan
- `.venv/bin/python -m pytest`