### PR TITLE
chore: expand planframe __all__ exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ df = out.collect()
   - `collect()` executes the accumulated plan using the adapter/backend
   - `materialize_model(kind="dataclass" | "pydantic")` materializes a Python model from the derived schema (no execution)
 
+### Public API (stable imports)
+
+Preferred imports:
+
+- `from planframe import Frame, Schema, JoinOptions, execute_plan`
+- `from planframe import expr` (then `expr.col`, `expr.lit`, `expr.add`, ...)
+
+Backend-specific frames (example):
+
+- `from planframe_polars import PolarsFrame`
+
 ### Execution model
 
 - **Always lazy**: chaining operations does not touch backend data.

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -1,5 +1,33 @@
+"""PlanFrame public entry points.
+
+These re-exports are intended to be stable, discoverable imports for end-users.
+For everything else, prefer importing from the submodules directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
 from planframe.execution import execute_plan
 from planframe.frame import Frame
+from planframe.groupby import GroupedFrame
+from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
 
-__all__ = ["Frame", "Schema", "execute_plan"]
+
+def __getattr__(name: str) -> Any:
+    # Lazily expose `planframe.expr` to avoid import-time cycles.
+    if name == "expr":
+        return importlib.import_module("planframe.expr")
+    raise AttributeError(name)
+
+
+__all__ = [
+    "Frame",
+    "Schema",
+    "GroupedFrame",
+    "JoinOptions",
+    "execute_plan",
+    "expr",
+]


### PR DESCRIPTION
Fixes #20

## Summary
- Expand `planframe/__init__.py` re-exports for discoverability: `Frame`, `Schema`, `JoinOptions`, `GroupedFrame`, `execute_plan`.
- Expose `planframe.expr` via lazy `__getattr__` to avoid import-time cycles.
- Document preferred imports in the root README.

## Test plan
- `ruff format && ruff check`
- `.venv/bin/python -m ty check`
- `.venv/bin/python -m pytest`