### PR TITLE
feat: add PlanNode walker (iter_plan_nodes)

### DIFF
--- a/docs/planframe_backend_adapter_design.md
+++ b/docs/planframe_backend_adapter_design.md
@@ -416,6 +416,12 @@ The **shipped** `BaseAdapter` in this repository extends that surface (joins, so
 
 Adapter tests should be split into two groups.
 
+### Plan introspection (tooling)
+
+Tool builders and adapter authors can walk a plan tree using `planframe.plan.iter_plan_nodes`.
+By default it traverses only the primary `prev` chain; pass `include_side_frames=True` to
+also descend into join/concat side frames (RHS/other frame plans) in a deterministic order.
+
 ### Conformance tests
 These test that every backend satisfies the same logical behavior.
 

--- a/packages/planframe/planframe/plan/__init__.py
+++ b/packages/planframe/planframe/plan/__init__.py
@@ -19,6 +19,7 @@ from planframe.plan.nodes import (
     Unique,
     WithColumn,
 )
+from planframe.plan.walk import iter_plan_nodes
 
 __all__ = [
     "JoinOptions",
@@ -40,4 +41,5 @@ __all__ = [
     "Source",
     "Unique",
     "WithColumn",
+    "iter_plan_nodes",
 ]

--- a/packages/planframe/planframe/plan/walk.py
+++ b/packages/planframe/planframe/plan/walk.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import cast
+
+from planframe.backend.errors import PlanFrameBackendError
+from planframe.plan.nodes import (
+    Agg,
+    ConcatHorizontal,
+    ConcatVertical,
+    GroupBy,
+    Join,
+    PlanNode,
+)
+from planframe.typing.frame_like import FrameLike
+
+
+def iter_plan_nodes(*, root: PlanNode, include_side_frames: bool = False) -> Iterator[PlanNode]:
+    """Iterate plan nodes in a deterministic pre-order traversal.
+
+    Pre-order means the current node is yielded before its children.
+
+    By default this walks only the linear `prev` chain (the primary pipeline). Nodes that
+    reference other frames (`Join.right`, concat `other`) are treated as boundaries and
+    are *not* descended into unless `include_side_frames=True`.
+
+    When `include_side_frames=True`, the traversal yields:
+    - the current node
+    - then its `prev` subtree (depth-first)
+    - then any side frame subtrees (depth-first), in a stable order:
+      - for `Join`: RHS (`right`) after the left chain
+      - for concats: `other` after the left chain
+    """
+
+    def _frame_plan(frame: FrameLike) -> PlanNode:
+        plan = getattr(frame, "_plan", None)
+        if not isinstance(plan, PlanNode):
+            raise PlanFrameBackendError("Side frame does not contain a valid PlanNode plan")
+        return plan
+
+    stack: list[PlanNode] = [root]
+    while stack:
+        node = stack.pop()
+        yield node
+
+        # Special-case nodes whose semantics mean "next node is not meaningful by itself".
+        # GroupBy only becomes meaningful when immediately followed by Agg; traversal should
+        # still remain deterministic, so we just recurse into prev like any other node.
+        if isinstance(node, Agg) and isinstance(node.prev, GroupBy):
+            # `Agg.prev` is a GroupBy node; the "real" input is `GroupBy.prev`.
+            # We still visit GroupBy itself as part of the tree.
+            stack.append(node.prev)
+            continue
+
+        # Side frames (optional)
+        if include_side_frames:
+            if isinstance(node, Join):
+                stack.append(_frame_plan(node.right))
+            elif isinstance(node, (ConcatVertical, ConcatHorizontal)):
+                stack.append(_frame_plan(node.other))
+
+        # Primary chain
+        prev = getattr(node, "prev", None)
+        if isinstance(prev, PlanNode):
+            stack.append(prev)

--- a/tests/test_plan_walk.py
+++ b/tests/test_plan_walk.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from planframe.plan.walk import iter_plan_nodes
+from planframe_polars import PolarsFrame
+
+
+def test_iter_plan_nodes_linear_chain_preorder() -> None:
+    class S(PolarsFrame):
+        id: int
+        a: int | None
+
+    pf = S({"id": [1], "a": [None]})
+    out = pf.select("id", "a").fill_null(0, "a").drop_nulls("a").head(1)
+
+    names = [type(n).__name__ for n in iter_plan_nodes(root=out.plan())]
+    assert names[:4] == ["Head", "DropNulls", "FillNull", "Select"]
+    assert names[-1] == "Source"
+
+
+def test_iter_plan_nodes_join_does_not_descend_rhs_by_default() -> None:
+    class L(PolarsFrame):
+        id: int
+        k1: int
+
+    class R(PolarsFrame):
+        id: int
+        k1: int
+
+    left = L({"id": [1], "k1": [1]})
+    right = R({"id": [1], "k1": [1]})
+    joined = left.join(right, on=("k1",))
+
+    names = [type(n).__name__ for n in iter_plan_nodes(root=joined.plan())]
+    # Should traverse only the LHS chain + Join itself.
+    assert names[0] == "Join"
+    assert names[-1] == "Source"
+    assert names.count("Source") == 1
+
+
+def test_iter_plan_nodes_join_can_include_rhs_plan() -> None:
+    class L2(PolarsFrame):
+        id: int
+        k1: int
+
+    class R2(PolarsFrame):
+        id: int
+        k1: int
+
+    left = L2({"id": [1], "k1": [1]}).select("k1")
+    right = R2({"id": [1], "k1": [1]}).select("k1").head(1)
+    joined = left.join(right, on=("k1",))
+
+    names = [
+        type(n).__name__ for n in iter_plan_nodes(root=joined.plan(), include_side_frames=True)
+    ]
+    assert names[0] == "Join"
+    # One Source for LHS and one Source for RHS.
+    assert names.count("Source") == 2
+    # RHS nodes appear after LHS chain (deterministic order).
+    rhs_head_idx = names.index("Head")
+    assert rhs_head_idx > names.index("Select")


### PR DESCRIPTION
Fixes #21

## Summary
- Add `planframe.plan.iter_plan_nodes(root, include_side_frames=False)` for deterministic pre-order traversal of plan trees.
- Optional descent into join/concat side-frame subplans when requested.
- Add tests for linear chains and joins (with/without RHS traversal).
- Document the API briefly for tool builders.

## Test plan
- `ruff format && ruff check`
- `.venv/bin/python -m ty check`
- `.venv/bin/python -m pytest`