### PR TITLE
feat: cheap Frame.__repr__ for debugging

### DIFF
--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import Sequence
 from typing import Any, Generic, Literal, TypeVar, cast
@@ -100,6 +101,40 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         self._adapter = _adapter
         self._plan = _plan
         self._schema = _schema
+
+    def __repr__(self) -> str:
+        # Keep repr cheap: never execute, never compile expressions, and keep traversal bounded.
+        verbose = os.getenv("PLANFRAME_REPR_VERBOSE", "").lower() in {"1", "true", "yes", "on"}
+
+        cols = self._schema.names()
+        col_preview_limit = 12 if verbose else 6
+        if len(cols) <= col_preview_limit:
+            cols_preview = ", ".join(cols)
+        else:
+            head = ", ".join(cols[:col_preview_limit])
+            cols_preview = f"{head}, …(+{len(cols) - col_preview_limit})"
+
+        # Plan shape: follow the primary `prev` chain for a small number of nodes.
+        plan_limit = 20 if verbose else 6
+        kinds: list[str] = []
+        node: PlanNode | None = self._plan
+        schema_type_name: str | None = None
+        steps = 0
+        while isinstance(node, PlanNode) and steps < plan_limit:
+            kinds.append(type(node).__name__)
+            if isinstance(node, Source) and schema_type_name is None:
+                schema_type_name = getattr(node.schema_type, "__name__", None)
+            prev = getattr(node, "prev", None)
+            node = prev if isinstance(prev, PlanNode) else None
+            steps += 1
+
+        if node is not None:
+            kinds.append("…")
+
+        plan_preview = "->".join(kinds)
+        schema_tag = f"[{schema_type_name}]" if schema_type_name else ""
+        adapter_tag = f", adapter={self._adapter.name!r}" if verbose else ""
+        return f"Frame{schema_tag}(cols={len(cols)} [{cols_preview}], plan={plan_preview}{adapter_tag})"
 
     @classmethod
     def source(

--- a/tests/test_frame_repr.py
+++ b/tests/test_frame_repr.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from planframe.frame import Frame
+from planframe.plan.nodes import Source
+from planframe.schema.ir import Field, Schema
+
+
+class DummyAdapter:
+    name = "dummy"
+
+
+def test_frame_repr_is_bounded_and_side_effect_free() -> None:
+    adapter = DummyAdapter()
+    data = object()
+
+    # Wide schema to force truncation.
+    wide = Schema(fields=tuple(Field(name=f"c{i}", dtype=int) for i in range(30)))
+    pf = Frame(
+        _data=data, _adapter=adapter, _plan=Source(schema_type=object, ir_version=1), _schema=wide
+    )
+
+    s = repr(pf)
+
+    assert s.startswith("Frame")
+    assert "cols=30" in s
+    assert "plan=Source" in s
+    assert "c0" in s
+    assert "…(+24)" in s


### PR DESCRIPTION
## Summary
- Add a human-friendly `Frame.__repr__` for notebook/debugging.
- Repr is bounded and side-effect free: it only inspects cached schema names and a shallow plan `prev` chain.
- Supports an opt-in verbose mode via `PLANFRAME_REPR_VERBOSE=1` for longer previews.

Fixes #25.

## Test plan
- `ruff format && ruff check`
- `python -m ty check`
- `pytest`