### PR TITLE
Fix #47: add group_by_dynamic + rolling_agg

### DIFF
--- a/packages/planframe-pandas/planframe_pandas/adapter.py
+++ b/packages/planframe-pandas/planframe_pandas/adapter.py
@@ -267,6 +267,32 @@ class PandasAdapter(BaseAdapter[PandasBackendFrame, PandasBackendExpr]):
             out = out.drop(columns=tmp_cols)
         return res
 
+    def group_by_dynamic_agg(
+        self,
+        df: pd.DataFrame,
+        *,
+        index_column: str,
+        every: str,
+        period: str | None = None,
+        by: tuple[str, ...] | None = None,
+        named_aggs: dict[str, tuple[str, str] | PandasBackendExpr],
+    ) -> pd.DataFrame:
+        raise PlanFrameBackendError("pandas adapter does not implement group_by_dynamic_agg")
+
+    def rolling_agg(
+        self,
+        df: pd.DataFrame,
+        *,
+        on: str,
+        column: str,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: tuple[str, ...] | None = None,
+        min_periods: int = 1,
+    ) -> pd.DataFrame:
+        raise PlanFrameBackendError("pandas adapter does not implement rolling_agg")
+
     def melt(
         self,
         df: pd.DataFrame,

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -181,6 +181,118 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
                 agg_exprs.append(expr.alias(out_name))
         return df.group_by(*by_exprs).agg(agg_exprs)
 
+    def group_by_dynamic_agg(
+        self,
+        df: PolarsBackendFrame,
+        *,
+        index_column: str,
+        every: str,
+        period: str | None = None,
+        by: tuple[str, ...] | None = None,
+        named_aggs: dict[str, tuple[str, str] | pl.Expr],
+    ) -> PolarsBackendFrame:
+        if not every:
+            raise ValueError("every must be non-empty")
+
+        # Build aggregation expressions (same handling as group_by_agg).
+        agg_exprs: list[pl.Expr] = []
+        for out_name, spec in named_aggs.items():
+            if (
+                isinstance(spec, tuple)
+                and len(spec) == 2
+                and isinstance(spec[0], str)
+                and isinstance(spec[1], str)
+            ):
+                op = spec[0]
+                col: str = spec[1]
+                e = pl.col(col)
+                if op == "count":
+                    ex = e.count()
+                elif op == "sum":
+                    ex = e.sum()
+                elif op == "mean":
+                    ex = e.mean()
+                elif op == "min":
+                    ex = e.min()
+                elif op == "max":
+                    ex = e.max()
+                elif op == "n_unique":
+                    ex = e.n_unique()
+                else:
+                    raise ValueError(f"Unsupported agg op: {op!r}")
+                agg_exprs.append(ex.alias(out_name))
+            else:
+                expr = cast(pl.Expr, spec)
+                agg_exprs.append(expr.alias(out_name))
+
+        kwargs: dict[str, Any] = {"every": every}
+        if period is not None:
+            kwargs["period"] = period
+        if by is not None:
+            kwargs["by"] = list(by)
+
+        return df.group_by_dynamic(index_column, **kwargs).agg(agg_exprs)
+
+    def rolling_agg(
+        self,
+        df: PolarsBackendFrame,
+        *,
+        on: str,
+        column: str,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: tuple[str, ...] | None = None,
+        min_periods: int = 1,
+    ) -> PolarsBackendFrame:
+        # Ensure deterministic ordering for rolling windows.
+        df2 = df.sort(on)
+        base = pl.col(column)
+
+        if isinstance(window_size, int):
+            if op == "sum":
+                expr = base.rolling_sum(window_size=window_size, min_periods=min_periods)
+            elif op == "mean":
+                expr = base.rolling_mean(window_size=window_size, min_periods=min_periods)
+            elif op == "min":
+                expr = base.rolling_min(window_size=window_size, min_periods=min_periods)
+            elif op == "max":
+                expr = base.rolling_max(window_size=window_size, min_periods=min_periods)
+            elif op == "count":
+                expr = (
+                    base.is_not_null()
+                    .cast(pl.Int64)
+                    .rolling_sum(window_size=window_size, min_periods=min_periods)
+                )
+            else:
+                raise ValueError(f"Unsupported rolling op: {op!r}")
+        else:
+            # time-based rolling, use *_by on the on-column.
+            by_col = pl.col(on)
+            if op == "sum":
+                expr = base.rolling_sum_by(by_col, window_size=window_size, min_periods=min_periods)
+            elif op == "mean":
+                expr = base.rolling_mean_by(
+                    by_col, window_size=window_size, min_periods=min_periods
+                )
+            elif op == "min":
+                expr = base.rolling_min_by(by_col, window_size=window_size, min_periods=min_periods)
+            elif op == "max":
+                expr = base.rolling_max_by(by_col, window_size=window_size, min_periods=min_periods)
+            elif op == "count":
+                expr = (
+                    base.is_not_null()
+                    .cast(pl.Int64)
+                    .rolling_sum_by(by_col, window_size=window_size, min_periods=min_periods)
+                )
+            else:
+                raise ValueError(f"Unsupported rolling op: {op!r}")
+
+        if by is not None:
+            expr = expr.over(list(by))
+
+        return df2.with_columns(expr.alias(out_name))
+
     def drop_nulls(
         self,
         df: PolarsBackendFrame,

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+from planframe.dynamic_groupby import DynamicGroupedFrame
 from planframe.execution import execute_plan
 from planframe.frame import Frame
 from planframe.groupby import GroupedFrame
@@ -27,6 +28,7 @@ __all__ = [
     "Frame",
     "Schema",
     "GroupedFrame",
+    "DynamicGroupedFrame",
     "JoinOptions",
     "execute_plan",
     "expr",

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -155,6 +155,36 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
         ...
 
     @abstractmethod
+    def group_by_dynamic_agg(
+        self,
+        df: BackendFrameT,
+        *,
+        index_column: str,
+        every: str,
+        period: str | None = None,
+        by: Columns | None = None,
+        named_aggs: dict[ColumnName, AggSpec],
+    ) -> BackendFrameT:
+        """Dynamic time-window group-by aggregation."""
+        ...
+
+    @abstractmethod
+    def rolling_agg(
+        self,
+        df: BackendFrameT,
+        *,
+        on: str,
+        column: str,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: Columns | None = None,
+        min_periods: int = 1,
+    ) -> BackendFrameT:
+        """Rolling window aggregation producing a new column."""
+        ...
+
+    @abstractmethod
     def drop_nulls(
         self,
         df: BackendFrameT,

--- a/packages/planframe/planframe/dynamic_groupby.py
+++ b/packages/planframe/planframe/dynamic_groupby.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+
+from planframe.backend.errors import PlanFrameSchemaError
+from planframe.expr.api import AggExpr, Expr, infer_dtype
+from planframe.plan.nodes import DynamicGroupByAgg, PlanNode
+from planframe.schema.ir import Field, Schema, collect_col_names_in_expr
+
+if TYPE_CHECKING:
+    from planframe.backend.adapter import BackendAdapter
+    from planframe.frame import Frame
+
+SchemaT = TypeVar("SchemaT")
+BackendFrameT = TypeVar("BackendFrameT")
+BackendExprT = TypeVar("BackendExprT")
+
+AggOp = Literal["count", "sum", "mean", "min", "max", "n_unique"]
+
+
+class DynamicGroupedFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
+    __slots__ = (
+        "_data",
+        "_adapter",
+        "_plan",
+        "_schema",
+        "_index_column",
+        "_every",
+        "_period",
+        "_by",
+    )
+
+    _data: BackendFrameT
+    _adapter: BackendAdapter[BackendFrameT, BackendExprT]
+    _plan: PlanNode
+    _schema: Schema
+    _index_column: str
+    _every: str
+    _period: str | None
+    _by: tuple[str, ...] | None
+
+    def __init__(
+        self,
+        *,
+        _data: BackendFrameT,
+        _adapter: BackendAdapter[BackendFrameT, BackendExprT],
+        _plan: PlanNode,
+        _schema: Schema,
+        _index_column: str,
+        _every: str,
+        _period: str | None,
+        _by: tuple[str, ...] | None,
+    ) -> None:
+        self._data = _data
+        self._adapter = _adapter
+        self._plan = _plan
+        self._schema = _schema
+        self._index_column = _index_column
+        self._every = _every
+        self._period = _period
+        self._by = _by
+
+    def agg(
+        self, **named_aggs: tuple[AggOp, str] | Expr[Any]
+    ) -> Frame[Any, BackendFrameT, BackendExprT]:
+        if not named_aggs:
+            raise PlanFrameSchemaError("agg requires at least one named aggregation")
+
+        # Output schema: index + by + agg fields.
+        out_fields: list[Field] = []
+        out_fields.append(self._schema.get(self._index_column))
+        if self._by is not None:
+            for c in self._by:
+                out_fields.append(self._schema.get(c))
+
+        fm = self._schema.field_map()
+        for out_name, spec in named_aggs.items():
+            if (
+                isinstance(spec, tuple)
+                and len(spec) == 2
+                and isinstance(spec[0], str)
+                and isinstance(spec[1], str)
+            ):
+                op = spec[0]
+                col = spec[1]
+                self._schema.get(col)
+                dtype: object = object
+                if op in {"count", "n_unique"}:
+                    dtype = int
+                out_fields.append(Field(name=out_name, dtype=dtype))
+            elif isinstance(spec, AggExpr):
+                missing = collect_col_names_in_expr(spec.inner).difference(fm.keys())
+                if missing:
+                    raise PlanFrameSchemaError(
+                        f"aggregation expression references unknown columns: {sorted(missing)}"
+                    )
+                out_fields.append(Field(name=out_name, dtype=infer_dtype(spec)))
+            else:
+                raise PlanFrameSchemaError(
+                    "agg expects (op, column_name) tuples or agg_sum/agg_mean/...(...) "
+                    f"over an expression, got {type(spec).__name__!r}"
+                )
+
+        schema2 = Schema(fields=tuple(out_fields))
+        plan2 = DynamicGroupByAgg(
+            prev=self._plan,
+            index_column=self._index_column,
+            every=self._every,
+            period=self._period,
+            by=self._by,
+            named_aggs=dict(named_aggs),
+        )
+
+        from planframe.frame import Frame  # avoid cycle
+
+        return Frame(_data=self._data, _adapter=self._adapter, _plan=plan2, _schema=schema2)

--- a/packages/planframe/planframe/execution.py
+++ b/packages/planframe/planframe/execution.py
@@ -19,6 +19,7 @@ from planframe.plan.nodes import (
     DropNulls,
     DropNullsAll,
     Duplicated,
+    DynamicGroupByAgg,
     Explode,
     FillNull,
     Filter,
@@ -34,6 +35,7 @@ from planframe.plan.nodes import (
     Project,
     ProjectPick,
     Rename,
+    RollingAgg,
     Sample,
     Select,
     Slice,
@@ -178,6 +180,16 @@ def execute_plan(
                 keys=compiled_keys,
                 named_aggs=compiled_aggs,
             )
+        if isinstance(node, DynamicGroupByAgg):
+            compiled_aggs = _compile_named_aggs(node.named_aggs)
+            return adapter.group_by_dynamic_agg(
+                _eval(node.prev),
+                index_column=node.index_column,
+                every=node.every,
+                period=node.period,
+                by=node.by,
+                named_aggs=compiled_aggs,
+            )
         if isinstance(node, DropNulls):
             return adapter.drop_nulls(
                 _eval(node.prev),
@@ -259,6 +271,17 @@ def execute_plan(
                 on_columns=node.on_columns,
                 separator=node.separator,
                 sort_columns=node.sort_columns,
+            )
+        if isinstance(node, RollingAgg):
+            return adapter.rolling_agg(
+                _eval(node.prev),
+                on=node.on,
+                column=node.column,
+                window_size=node.window_size,
+                op=node.op,
+                out_name=node.out_name,
+                by=node.by,
+                min_periods=node.min_periods,
             )
         if isinstance(node, Explode):
             return adapter.explode(_eval(node.prev), node.columns, outer=node.outer)

--- a/packages/planframe/planframe/frame.py
+++ b/packages/planframe/planframe/frame.py
@@ -14,6 +14,7 @@ from planframe.backend.errors import (
     PlanFrameExecutionError,
     PlanFrameSchemaError,
 )
+from planframe.dynamic_groupby import DynamicGroupedFrame
 from planframe.execution import execute_plan
 from planframe.expr.api import Expr, infer_dtype
 from planframe.groupby import GroupedFrame
@@ -41,6 +42,7 @@ from planframe.plan.nodes import (
     ProjectExpr,
     ProjectPick,
     Rename,
+    RollingAgg,
     Sample,
     Select,
     Slice,
@@ -597,6 +599,79 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
             _plan=self._plan,
             _schema=self._schema,
             _key_items=items,
+        )
+
+    def group_by_dynamic(
+        self,
+        index_column: str,
+        *,
+        every: str,
+        period: str | None = None,
+        by: Sequence[str] | None = None,
+    ) -> DynamicGroupedFrame[SchemaT, BackendFrameT, BackendExprT]:
+        self._schema.get(index_column)
+        by_tup = tuple(by) if by is not None else None
+        if by_tup is not None:
+            self._schema.select(by_tup)
+        if not every:
+            raise ValueError("group_by_dynamic requires non-empty every")
+        if period is not None and not period:
+            raise ValueError("group_by_dynamic period must be non-empty when provided")
+
+        return DynamicGroupedFrame(
+            _data=self._data,
+            _adapter=self._adapter,
+            _plan=self._plan,
+            _schema=self._schema,
+            _index_column=index_column,
+            _every=every,
+            _period=period,
+            _by=by_tup,
+        )
+
+    def rolling_agg(
+        self,
+        *,
+        on: str,
+        column: str,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: Sequence[str] | None = None,
+        min_periods: int = 1,
+    ) -> Frame[SchemaT, BackendFrameT, BackendExprT]:
+        self._schema.get(on)
+        self._schema.get(column)
+        by_tup = tuple(by) if by is not None else None
+        if by_tup is not None:
+            self._schema.select(by_tup)
+        if isinstance(window_size, int) and window_size <= 0:
+            raise ValueError("rolling_agg window_size must be positive")
+        if isinstance(window_size, str) and not window_size:
+            raise ValueError("rolling_agg window_size must be non-empty")
+        if min_periods <= 0:
+            raise ValueError("rolling_agg min_periods must be positive")
+        if not out_name:
+            raise ValueError("rolling_agg requires non-empty out_name")
+
+        dtype: object = object
+        if op in {"count"}:
+            dtype = int
+        schema2 = self._schema.with_column(out_name, dtype=dtype)
+        return Frame(
+            _data=self._data,
+            _adapter=self._adapter,
+            _plan=RollingAgg(
+                self._plan,
+                on=on,
+                column=column,
+                window_size=window_size,
+                op=op,
+                out_name=out_name,
+                by=by_tup,
+                min_periods=min_periods,
+            ),
+            _schema=schema2,
         )
 
     def drop_nulls(

--- a/packages/planframe/planframe/frame.pyi
+++ b/packages/planframe/planframe/frame.pyi
@@ -6,6 +6,7 @@ from typing import Any, Generic, Literal, TypeVar, overload
 from typing_extensions import LiteralString, Self
 
 from planframe.backend.adapter import BackendAdapter
+from planframe.dynamic_groupby import DynamicGroupedFrame
 from planframe.expr.api import Expr
 from planframe.groupby import GroupedFrame
 from planframe.plan.join_options import JoinOptions
@@ -923,6 +924,14 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         self, *keys: LiteralString | Expr[Any]
     ) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     def group_by(self, *keys: Any) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
+    def group_by_dynamic(
+        self,
+        index_column: LiteralString,
+        *,
+        every: str,
+        period: str | None = ...,
+        by: tuple[LiteralString, ...] | None = ...,
+    ) -> DynamicGroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...
     @overload
     def drop_nulls(
         self, *subset: LiteralString, how: Literal["any", "all"] = ..., threshold: int | None = ...
@@ -1470,3 +1479,14 @@ class Frame(Generic[SchemaT, BackendFrameT, BackendExprT]):
         *,
         kind: Literal["dataclass", "pydantic"] = ...,
     ) -> type[Any]: ...
+    def rolling_agg(
+        self,
+        *,
+        on: LiteralString,
+        column: LiteralString,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: tuple[LiteralString, ...] | None = ...,
+        min_periods: int = ...,
+    ) -> Self: ...

--- a/packages/planframe/planframe/plan/nodes.py
+++ b/packages/planframe/planframe/plan/nodes.py
@@ -147,6 +147,28 @@ class Agg(PlanNode):
 
 
 @dataclass(frozen=True, slots=True)
+class DynamicGroupByAgg(PlanNode):
+    prev: PlanNode
+    index_column: str
+    every: str
+    period: str | None
+    by: tuple[str, ...] | None
+    named_aggs: dict[str, tuple[str, str] | Expr[Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class RollingAgg(PlanNode):
+    prev: PlanNode
+    on: str
+    column: str
+    window_size: int | str
+    op: str
+    out_name: str
+    by: tuple[str, ...] | None
+    min_periods: int = 1
+
+
+@dataclass(frozen=True, slots=True)
 class DropNulls(PlanNode):
     prev: PlanNode
     subset: tuple[str, ...] | None

--- a/scripts/generate_typing_stubs.py
+++ b/scripts/generate_typing_stubs.py
@@ -59,6 +59,7 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a("from planframe.backend.adapter import BackendAdapter")
     a("from planframe.expr.api import Expr")
     a("from planframe.groupby import GroupedFrame")
+    a("from planframe.dynamic_groupby import DynamicGroupedFrame")
     a("from planframe.plan.join_options import JoinOptions")
     a("from planframe.plan.nodes import PlanNode")
     a("from planframe.schema.ir import Schema")
@@ -321,6 +322,14 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a(
         "    def group_by(self, *keys: Any) -> GroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ..."
     )
+    a("    def group_by_dynamic(")
+    a("        self,")
+    a("        index_column: LiteralString,")
+    a("        *,")
+    a("        every: str,")
+    a("        period: str | None = ...,")
+    a("        by: tuple[LiteralString, ...] | None = ...,")
+    a("    ) -> DynamicGroupedFrame[SchemaT, BackendFrameT, BackendExprT]: ...")
     a("    @overload")
     a(
         '    def drop_nulls(self, *subset: LiteralString, how: Literal["any", "all"] = ..., threshold: int | None = ...) -> Self: ...'
@@ -597,6 +606,18 @@ def _render_frame_pyi(*, max_arity: int = 10) -> str:
     a('        kind: Literal["dataclass", "pydantic"] = ...,')
     a("    ) -> type[Any]: ...")
     a("")
+
+    a("    def rolling_agg(")
+    a("        self,")
+    a("        *,")
+    a("        on: LiteralString,")
+    a("        column: LiteralString,")
+    a("        window_size: int | str,")
+    a("        op: str,")
+    a("        out_name: str,")
+    a("        by: tuple[LiteralString, ...] | None = ...,")
+    a("        min_periods: int = ...,")
+    a("    ) -> Self: ...")
 
     return "\n".join(lines)
 

--- a/tests/pyright/pass/group_by_dynamic.py
+++ b/tests/pyright/pass/group_by_dynamic.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from planframe_polars import PolarsFrame
+
+
+class S(PolarsFrame):
+    ts: int
+    g: str
+    x: int
+
+
+pf = S({"ts": [1], "g": ["a"], "x": [10]})
+out = pf.group_by_dynamic("ts", every="1h", by=("g",)).agg(n=("count", "x"))
+df = out.collect()

--- a/tests/pyright/pass/rolling_agg.py
+++ b/tests/pyright/pass/rolling_agg.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from planframe_polars import PolarsFrame
+
+
+class S(PolarsFrame):
+    ts: int
+    x: int
+
+
+pf = S({"ts": [1], "x": [10]})
+out = pf.rolling_agg(on="ts", column="x", window_size=2, op="mean", out_name="x_roll")
+df = out.collect()

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -319,6 +319,58 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
             out.append(dict(base))
         return out
 
+    def group_by_dynamic_agg(
+        self,
+        df: list[dict[str, Any]],
+        *,
+        index_column: str,
+        every: str,
+        period: str | None = None,
+        by: tuple[str, ...] | None = None,
+        named_aggs: dict[str, tuple[str, str] | AggExpr],
+    ) -> list[dict[str, Any]]:
+        self.calls.append(
+            ("group_by_dynamic_agg", (index_column, every, period, by, dict(named_aggs)))
+        )
+        # Minimal: no actual windowing; just aggregate over the full input keyed by (index_column, *by).
+        keys = (index_column, *(() if by is None else by))
+        groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+        for row in df:
+            k = tuple(row.get(c) for c in keys)
+            groups.setdefault(k, []).append(row)
+
+        out: list[dict[str, Any]] = []
+        for k, rows in groups.items():
+            base: dict[str, Any] = {keys[i]: k[i] for i in range(len(keys))}
+            for out_name, spec in named_aggs.items():
+                if isinstance(spec, tuple):
+                    op, col_name = spec
+                    vals = [r[col_name] for r in rows]
+                    base[out_name] = _spy_agg_reduce(vals, op)
+                elif isinstance(spec, AggExpr):
+                    inner_vals = [_spy_row_expr(r, spec.inner) for r in rows]
+                    base[out_name] = _spy_agg_reduce(inner_vals, spec.op)
+                else:
+                    raise TypeError("unexpected agg spec")
+            out.append(dict(base))
+        return out
+
+    def rolling_agg(
+        self,
+        df: list[dict[str, Any]],
+        *,
+        on: str,
+        column: str,
+        window_size: int | str,
+        op: str,
+        out_name: str,
+        by: tuple[str, ...] | None = None,
+        min_periods: int = 1,
+    ) -> list[dict[str, Any]]:
+        self.calls.append(("rolling_agg", (on, column, window_size, op, out_name, by, min_periods)))
+        # Minimal: just add the output column as a placeholder.
+        return [{**row, out_name: "computed"} for row in df]
+
     def drop_nulls(
         self,
         df: list[dict[str, Any]],
@@ -1377,6 +1429,37 @@ def test_posexplode_is_lazy_and_adds_pos_and_value_columns() -> None:
     rows = out.collect()
     assert rows == [{"id": 1, "pos": 0, "xs": 10}, {"id": 1, "pos": 1, "xs": 20}]
     assert [c[0] for c in adapter.calls] == ["posexplode", "collect"]
+
+
+def test_group_by_dynamic_is_lazy() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class S:
+        ts: int
+        g: str
+        x: int
+
+    pf = Frame.source([{"ts": 1, "g": "a", "x": 10}], adapter=adapter, schema=S)
+    out = pf.group_by_dynamic("ts", every="1h", by=("g",)).agg(n=("count", "x"))
+    assert adapter.calls == []
+    _ = out.collect()
+    assert [c[0] for c in adapter.calls] == ["group_by_dynamic_agg", "collect"]
+
+
+def test_rolling_agg_is_lazy() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class S:
+        ts: int
+        x: int
+
+    pf = Frame.source([{"ts": 1, "x": 10}], adapter=adapter, schema=S)
+    out = pf.rolling_agg(on="ts", column="x", window_size=2, op="mean", out_name="x_roll")
+    assert adapter.calls == []
+    _ = out.collect()
+    assert [c[0] for c in adapter.calls] == ["rolling_agg", "collect"]
 
 
 def test_write_methods_execute_and_are_boundaries(tmp_path: Any) -> None:

--- a/tests/test_execute_plan_nodes.py
+++ b/tests/test_execute_plan_nodes.py
@@ -317,6 +317,32 @@ def test_execute_plan_posexplode() -> None:
     assert res == [{"id": 1, "pos": 0, "xs": 5}, {"id": 1, "pos": 1, "xs": 6}]
 
 
+def test_execute_plan_group_by_dynamic_and_rolling_agg() -> None:
+    adapter = SpyAdapter()
+
+    @dataclass(frozen=True)
+    class S2:
+        ts: int
+        g: str
+        x: int
+
+    pf = Frame.source(
+        [{"ts": 1, "g": "a", "x": 10}, {"ts": 1, "g": "a", "x": 20}],
+        adapter=adapter,
+        schema=S2,
+    )
+
+    dyn = pf.group_by_dynamic("ts", every="1h", by=("g",)).agg(n=("count", "x"))
+    res_dyn, calls_dyn = _run(dyn)
+    assert calls_dyn == ["group_by_dynamic_agg"]
+    assert len(res_dyn) == 1
+
+    roll = pf.rolling_agg(on="ts", column="x", window_size=2, op="mean", out_name="x_roll")
+    res_roll, calls_roll = _run(roll)
+    assert calls_roll == ["rolling_agg"]
+    assert "x_roll" in res_roll[0]
+
+
 def test_execute_plan_join_and_concat_and_backend_mismatch_errors() -> None:
     adapter = SpyAdapter()
     left = Frame.source([{"id": 1, "a": 1, "b": 0}], adapter=adapter, schema=S)


### PR DESCRIPTION
## Summary
- Add `Frame.group_by_dynamic(...).agg(...)` to represent time-windowed groupby in PlanFrame IR.
- Add `Frame.rolling_agg(...)` as a plan node producing a new column.
- Implement Polars adapter support; pandas currently raises clear not-implemented errors.
- Add runtime + pyright tests and regenerate typing stubs.

## Test plan
- `ruff format .` and `ruff check .`
- `python -m ty check`
- `python -m pytest` (Python 3.10+)

Closes #47.