### PR TITLE
Docs: clarify async adapter execution contract

### DIFF
--- a/docs/planframe/design/backend-adapter-design.md
+++ b/docs/planframe/design/backend-adapter-design.md
@@ -160,7 +160,14 @@ PlanFrame stays **synchronous for lazy chaining**: building a `Frame` only updat
 
 `BaseAdapter` provides default `acollect` / `ato_dicts` / `ato_dict` that run the matching sync method in `asyncio.to_thread`, so existing adapters work without changes. Backends backed by asyncio-only clients should **override** `acollect` (and optionally `ato_dicts` / `ato_dict`) to await their native I/O instead of blocking a thread.
 
-**Plan evaluation** (`execute_plan` walking the `PlanNode` tree—what `Frame` runs before `collect` / `to_dict*`) remains synchronous on the event-loop thread; only adapter execution at the materialization boundary is async. Async backends should keep plan translation fast and perform I/O inside `acollect` (or related hooks).
+**Plan evaluation** (`execute_plan` walking the `PlanNode` tree—what `Frame` runs before `collect` / `to_dict*`) remains synchronous on the event-loop thread for both sync and async terminals. Concretely, `Frame.acollect_backend()` first computes `planned = Frame._eval(Frame.plan)` (synchronous), then awaits `BaseAdapter.acollect(planned, options=...)`.
+
+**ExecutionOptions propagation:** the optional `options: ExecutionOptions | None` is forwarded to both:
+
+- `execute_plan(..., options=...)` (plan interpretation / compilation context)
+- adapter materialization/export (`collect` / `to_dicts` / `to_dict` and async variants)
+
+Adapters should accept `options` and treat it as a set of backend-defined hints: forward what is meaningful for the engine, ignore unknown hints, and keep signatures stable for third-party consumers.
 
 **Thread safety:** default async methods may invoke the adapter from multiple thread-pool workers concurrently if several `acollect` tasks run in parallel. Adapters that mutate shared connection state should document constraints or serialize; thread-local or per-task clients are typical.
 

--- a/docs/planframe/guides/creating-an-adapter.md
+++ b/docs/planframe/guides/creating-an-adapter.md
@@ -70,6 +70,47 @@ Materialization and row export happen only at execution boundaries. On `BaseAdap
 
 `Frame.collect_backend`, `Frame.to_dicts`, `Frame.to_dict`, and the async counterparts accept the same `ExecutionOptions` and pass them through to the adapter.
 
+## Async execution contract (third-party adapters)
+
+PlanFrame’s **lazy chaining is always synchronous**: building a `Frame` never does I/O and never awaits. Async support exists only at **materialization boundaries**.
+
+### Call graph (what runs on async terminals)
+
+All materialization paths evaluate the plan the same way:
+
+- **Sync**: `Frame.collect_backend()` / `Frame.to_dicts()` / `Frame.to_dict()`
+  - Plan evaluation: `planned = execute_plan(frame.plan, adapter=..., schema=..., options=...)` (via `Frame._eval`)
+  - Adapter boundary: `adapter.collect(planned, options=...)` then `adapter.to_dicts(...)` / `adapter.to_dict(...)`
+- **Async**: `Frame.acollect_backend()` / `Frame.ato_dicts()` / `Frame.ato_dict()` / `Frame.acollect()`
+  - Plan evaluation: **still synchronous** (`planned = frame._eval(frame.plan)` on the event loop thread)
+  - Adapter boundary: awaits `adapter.acollect(planned, options=...)` / `adapter.ato_dicts(...)` / `adapter.ato_dict(...)`
+
+**Implication:** async terminals still go through PlanFrame’s interpreter. Third-party adapters should not bypass `execute_plan` by delegating async paths directly to the underlying engine unless they are intentionally opting out of PlanFrame’s execution/options semantics.
+
+### What `BaseAdapter` must implement for async
+
+- **Minimum**: implement the sync boundaries (`collect`, `to_dicts`, `to_dict`) and accept `options=...`.
+  - You get async terminals “for free” via `BaseAdapter.acollect` / `ato_dicts` / `ato_dict`, which wrap sync work in `asyncio.to_thread`.
+- **Async-native backends**: override `acollect` and usually also `ato_dicts` / `ato_dict` to avoid blocking a worker thread.
+  - Keep `acollect` focused on I/O / engine execution; plan translation should already be completed before it’s called.
+
+### `ExecutionOptions` propagation
+
+`ExecutionOptions` is forwarded to:
+
+- `execute_plan(..., options=...)` (plan execution / compilation context)
+- adapter materialization/export methods (`collect` / `to_dicts` / `to_dict` and async variants)
+
+Adapters should treat `ExecutionOptions` fields as **hints**: forward only what your engine understands, ignore unknown hints, and keep the parameter on public signatures for forward compatibility.
+
+### Thread-safety expectations (important)
+
+If you rely on the default async methods (the `asyncio.to_thread` wrappers), your adapter’s sync boundaries may be invoked **concurrently** in multiple worker threads if users run multiple async collections at once.
+
+- If your backend client / connection object is not thread-safe, either:
+  - override async methods to use an async-native client, or
+  - serialize internally (locks) / use per-task clients, and **document** the limitation.
+
 ## Optional: row streaming + true async IO
 
 If your engine can stream rows (cursor-based DB reads, chunked readers, etc.), implement `AdapterRowStreamer` on your adapter. **Both** sync and async entrypoints are required: PlanFrame uses `isinstance(adapter, AdapterRowStreamer)`; an adapter that only defines `stream_dicts` is treated like a non-streaming adapter and will fall back to `to_dicts()` / `ato_dicts()`.


### PR DESCRIPTION
## Summary
- Document the async execution/materialization contract for third-party adapters.
- Clarify that async terminals still plan via `execute_plan` and that `ExecutionOptions` are forwarded through both plan evaluation and adapter boundaries.
- Call out thread-safety expectations when relying on default `asyncio.to_thread` implementations.

## Test plan
- [x] `ruff check docs`
- [x] `uv run mkdocs build --strict`

Fixes #77.