### PR TITLE
Docs: reframe Tier 3 Resolve without Pyright plugins

### DIFF
--- a/docs/planframe/design/package-plan.md
+++ b/docs/planframe/design/package-plan.md
@@ -170,7 +170,7 @@ The repository ships a flatter layout than this early sketch (`planframe/expr`, 
 - Use Literal for column names
 - Avoid Any leakage
 - Provide .pyi stubs if needed
-- Optional plugin for Resolve
+- Tier 3 “Resolve”: external resolver tool + generated artifacts (Pyright has no general plugin system)
 
 ---
 
@@ -190,7 +190,7 @@ Supported operations:
 
 # 12. Future Enhancements
 
-- Pyright plugin
+- Full Resolve tool (external) + improved stub/codegen integration
 - SQL compilation
 - schema diffing
 - query optimization

--- a/docs/planframe/design/resolve-tier-3.md
+++ b/docs/planframe/design/resolve-tier-3.md
@@ -1,0 +1,62 @@
+# Tier 3 Resolve: feasibility + scope (Pyright integration)
+
+PlanFrame’s typing design describes “Tier 3” as a **Pyright plugin** that can perform full logical **Resolve** (compute output column names and types across a `Frame` plan AST).
+
+## Feasibility: Pyright does not have a general plugin system
+
+Pyright intentionally does **not** support a general-purpose plugin model (unlike mypy). That means PlanFrame cannot ship a “Pyright plugin” in the usual sense: there is no supported hook point to run custom Python/TypeScript logic during type checking.
+
+**Implication:** Tier 3 should be implemented as a **PlanFrame-owned external resolver** that produces artifacts Pyright can already understand.
+
+## What Tier 3 should deliver (incremental)
+
+### 1) Spike (this document)
+
+Clarify constraints and pick an approach that is:
+
+- useful to adapter consumers,
+- maintainable by PlanFrame,
+- compatible with Pyright as it exists today.
+
+### 2) MVP: external resolver + artifact emission
+
+Define a small library surface (conceptual):
+
+- **input**: a PlanFrame plan (`PlanNode`) plus a starting schema
+- **output**: a “resolved schema view” (mapping `column_name -> python type`)
+
+Then integrate via artifacts:
+
+- **Generated stubs** (`.pyi`) for stable, pinned pipelines (Tier 2+)
+- **Materialization boundary** (`materialize_model`) for explicit, ergonomic schema snapshots
+
+### 3) Optional: editor workflow integration
+
+If desired, provide a dev tool that:
+
+- watches a project (or a list of pipelines),
+- regenerates stubs into a known directory, and
+- configures Pyright `extraPaths` to pick them up (similar to how this repo’s typing tests point Pyright at workspace packages).
+
+## Suggested MVP scope for full Resolve
+
+Start with a subset that matches the existing tiered docs:
+
+- `select`
+- `with_column`
+- `rename`
+- `drop`
+- `cast`
+- `filter` (schema-preserving)
+
+Then expand to:
+
+- `join` (suffix rules, nullability policies)
+- `group_by(...).agg(...)` (key synthesis like `__pf_g0`, named aggs, `AggExpr`)
+
+## CI strategy
+
+Keep Tier 1–2 as the default (overloads + generated stubs).
+
+If/when a resolver tool exists, add a **separate optional CI job** that runs the resolver over a curated set of pipelines and asserts it matches runtime schema derivation.
+

--- a/docs/planframe/design/typing-design.md
+++ b/docs/planframe/design/typing-design.md
@@ -126,7 +126,7 @@ So for Pyright-friendly design, there are only three realistic options:
 
 1. **Small static overload sets**
 2. **Generated `.pyi` stubs**
-3. **A Pyright plugin**
+3. **An external resolver tool (Tier 3)**
 
 For MVP, use 1 and 2. Plugin can come later.
 
@@ -300,6 +300,16 @@ For stable pipelines, emit `.pyi` or codegen classes.
 
 ### Tier 3 — Pyright plugin
 Implement full logical `Resolve` over the plan AST.
+
+#### Practical note (Pyright does not support plugins)
+Despite the name “Tier 3 — Pyright plugin” in early drafts, **Pyright does not currently support a general plugin system** (unlike mypy). This means Tier 3 cannot be implemented as an in-process Pyright plugin without upstream Pyright changes.
+
+Instead, Tier 3 should be treated as a **PlanFrame-owned external resolver** that can:
+
+- evaluate `Resolve` over a `PlanNode` tree, and
+- emit artifacts Pyright *can* consume (e.g. generated `.pyi` for stable pipelines, or codegen at explicit boundaries).
+
+See `resolve-tier-3.md` for the feasibility note and an incremental scope proposal.
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarify that Pyright does not support a general plugin system, so Tier 3 Resolve cannot be an in-process Pyright plugin.
- Reframe Tier 3 as an external PlanFrame resolver that emits artifacts Pyright can consume.
- Add an incremental scope proposal for full Resolve coverage.

## Test plan
- [x] `ruff check docs`
- [x] `uv run mkdocs build --strict`

Fixes #78.