### PR TITLE
Docs: patterns for embedding Frame in host types

### DIFF
--- a/docs/planframe/guides/embedding-frame.md
+++ b/docs/planframe/guides/embedding-frame.md
@@ -1,0 +1,84 @@
+# Embedding `Frame` in a host type (composition)
+
+Many integrations *wrap* a PlanFrame `Frame` inside a host type instead of subclassing backend frames like `PolarsFrame`.
+
+This guide documents Pyright-friendly patterns for doing that without copying PlanFrame’s generated stubs.
+
+## Recommended pattern: immutable host + `inner: Frame[...]`
+
+Use an immutable wrapper that carries the inner `Frame` and returns a new host on transforms.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Self, TypeVar
+
+from planframe import Frame
+
+SchemaT = TypeVar("SchemaT")
+BackendFrameT = TypeVar("BackendFrameT")
+BackendExprT = TypeVar("BackendExprT")
+
+
+@dataclass(frozen=True)
+class HostFrame(Generic[SchemaT, BackendFrameT, BackendExprT]):
+    inner: Frame[SchemaT, BackendFrameT, BackendExprT]
+
+    def select(self, *cols: str) -> Self:
+        # Delegate to PlanFrame, then re-wrap.
+        return type(self)(self.inner.select(*cols))
+
+    def to_frame(self) -> Frame[SchemaT, BackendFrameT, BackendExprT]:
+        # Provide an explicit escape hatch back to the PlanFrame surface.
+        return self.inner
+```
+
+### Notes
+
+- The wrapper stays **lazy** because `Frame.select(...)` only updates the plan.
+- Keep the host **immutable** (return a new instance) to match PlanFrame semantics and preserve reasoning about plans.
+- Prefer a single, consistently-named attribute like **`inner`** so it’s obvious where the PlanFrame surface lives.
+
+## Type helpers
+
+PlanFrame ships a small protocol for “host embeds a frame”:
+
+```python
+from planframe.typing import HasInnerFrame
+```
+
+This is useful in helper functions that can accept either your host type or a raw `Frame`.
+
+```python
+from __future__ import annotations
+
+from typing import TypeVar
+
+from planframe import Frame
+from planframe.typing import HasInnerFrame
+
+SchemaT = TypeVar("SchemaT")
+BackendFrameT = TypeVar("BackendFrameT")
+BackendExprT = TypeVar("BackendExprT")
+
+
+def unwrap_frame(
+    x: Frame[SchemaT, BackendFrameT, BackendExprT]
+    | HasInnerFrame[SchemaT, BackendFrameT, BackendExprT],
+) -> Frame[SchemaT, BackendFrameT, BackendExprT]:
+    return x if isinstance(x, Frame) else x.inner
+```
+
+If you want to support both shapes without `isinstance(x, Frame)`, prefer a separate overload set or require `HasInnerFrame` explicitly.
+
+## When to use `materialize_model`
+
+Composition wrappers are often used in apps that want a “schema snapshot” at a boundary.
+
+If your host type provides a higher-level API, consider exposing PlanFrame’s boundary:
+
+- `inner.materialize_model("Output", kind="dataclass")`
+
+This makes it easier for downstream users to get an explicit model type without needing full “Resolve”.
+

--- a/docs/planframe/index.md
+++ b/docs/planframe/index.md
@@ -8,6 +8,7 @@ PlanFrame core builds a typed plan and delegates execution to a backend via `Bas
 
 - Read the guide: [Creating an adapter](guides/creating-an-adapter.md)
 - Learn the row-export APIs: [Streaming rows](guides/streaming-rows.md)
+- Wrapping `Frame` in a host type: [Embedding `Frame` (composition)](guides/embedding-frame.md)
 - Optional **API skins** (typed mixins on `Frame`, no extra backend deps): [PySpark-like API](guides/pyspark-like-api.md), [pandas-like API](guides/pandas-like-api.md)
 - Browse the design docs under **Design** in the nav (including [Core layout](design/core-layout.md) for how `Frame`, compilation, and `execute_plan` fit together)
 - See adapters catalog: [Adapters](../adapters/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
           - Creating an adapter: planframe/guides/creating-an-adapter.md
           - Migrating to v1.0.0: planframe/guides/migrating-to-1-0.md
           - Streaming rows: planframe/guides/streaming-rows.md
+          - Embedding Frame (composition): planframe/guides/embedding-frame.md
           - PySpark-like API (SparkFrame): planframe/guides/pyspark-like-api.md
           - Pandas-like API (PandasLikeFrame): planframe/guides/pandas-like-api.md
       - Reference:

--- a/packages/planframe/planframe/typing/__init__.py
+++ b/packages/planframe/planframe/typing/__init__.py
@@ -1,1 +1,7 @@
 from __future__ import annotations
+
+from .host_frame import HasInnerFrame as HasInnerFrame
+from .scalars import Scalar as Scalar
+from .storage import StorageOptions as StorageOptions
+
+__all__ = ["HasInnerFrame", "Scalar", "StorageOptions"]

--- a/packages/planframe/planframe/typing/__init__.pyi
+++ b/packages/planframe/planframe/typing/__init__.pyi
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from ._schema_types import JoinedSchema as JoinedSchema
+from .host_frame import HasInnerFrame as HasInnerFrame
 from .scalars import Scalar as Scalar
 from .storage import StorageOptions as StorageOptions
 
-__all__ = ["JoinedSchema", "Scalar", "StorageOptions"]
+__all__ = ["HasInnerFrame", "JoinedSchema", "Scalar", "StorageOptions"]

--- a/packages/planframe/planframe/typing/host_frame.py
+++ b/packages/planframe/planframe/typing/host_frame.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from planframe.frame import Frame
+
+SchemaT = TypeVar("SchemaT")
+BackendFrameT = TypeVar("BackendFrameT")
+BackendExprT = TypeVar("BackendExprT")
+
+
+class HasInnerFrame(Protocol[SchemaT, BackendFrameT, BackendExprT]):
+    """Protocol for host types that embed a `Frame` by composition.
+
+    This is intended for third-party libraries that wrap PlanFrame in a façade type
+    (e.g. to carry validation state, I/O handles, or application-specific methods)
+    while still exposing a Pyright-friendly path back to the underlying `Frame`.
+    """
+
+    inner: Frame[SchemaT, BackendFrameT, BackendExprT]

--- a/tests/pyright/pass/embedding_frame_wrapper.py
+++ b/tests/pyright/pass/embedding_frame_wrapper.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Self
+
+from planframe import Frame
+from planframe.typing import HasInnerFrame
+
+
+@dataclass(frozen=True)
+class S:
+    id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class Host(HasInnerFrame[S, object, object]):
+    inner: Frame[S, object, object]
+
+    def select_id(self) -> Self:
+        # Re-wrap after delegating to Frame.
+        return type(self)(self.inner.select("id"))
+
+
+def f(x: Host) -> None:
+    # Ensure `.inner` preserves Frame typing.
+    _ = x.inner.select("id", "name")
+    # Ensure chaining through wrapper stays well-typed.
+    _ = x.select_id().inner.to_dicts()
+    # Ensure protocol is usable in helper types.
+    y: HasInnerFrame[S, object, object] = x
+    _ = y.inner.collect_backend()


### PR DESCRIPTION
## Summary
- Add a guide for Pyright-friendly composition wrappers that embed a `Frame`.
- Add `planframe.typing.HasInnerFrame` protocol for host types exposing an `inner: Frame[...]`.
- Add a Pyright pass example covering the pattern.

## Test plan
- [x] `ruff check`
- [x] `uv run mkdocs build --strict`
- [x] `pyright --project tests/pyright/pyrightconfig.json tests/pyright/pass/embedding_frame_wrapper.py`

Fixes #80.