### PR TITLE
Pydantic bridge: support base model for materialize_pydantic

### DIFF
--- a/docs/planframe/guides/pydantic-bridge.md
+++ b/docs/planframe/guides/pydantic-bridge.md
@@ -1,0 +1,55 @@
+# Optional Pydantic bridge for `materialize_model`
+
+PlanFrame’s `materialize_model(...)` boundary produces an exact row model from the derived schema.
+
+If you already have a Pydantic `BaseModel` you want to use as the “single source of truth” for validation (or you want to reuse a shared base class / config), you can bridge in a few simple ways.
+
+## 1) Generate a Pydantic model directly from a `Frame`
+
+```python
+RowModel = pf.materialize_model("RowModel", kind="pydantic")
+rows = pf.to_dicts()
+validated = [RowModel(**r) for r in rows]
+```
+
+This uses PlanFrame’s derived schema as the authoritative field set and types.
+
+## 2) Generate a Pydantic model that inherits your own base class
+
+PlanFrame exposes `materialize_pydantic(..., base=...)` for cases where you want custom validation config, mixins, or shared methods on your Pydantic models.
+
+```python
+from pydantic import BaseModel, ConfigDict
+
+from planframe.schema.materialize import materialize_pydantic
+
+
+class MyBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+RowModel = materialize_pydantic("RowModel", pf.schema(), base=MyBase)
+```
+
+## 3) Validate PlanFrame rows against an existing Pydantic model
+
+If you already have a Pydantic model type, validate PlanFrame’s row dicts using the Pydantic API:
+
+```python
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+rows = pf.to_dicts()
+validated = [User.model_validate(r) for r in rows]  # Pydantic v2
+```
+
+### Trade-offs
+
+- Validating against a pre-existing model can be great for “single source of truth”, but it may not match PlanFrame’s derived schema exactly (missing/extra fields, different optionality).
+- `materialize_model(..., kind="pydantic")` is best when you want PlanFrame’s schema to be authoritative at that boundary.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
           - Migrating to v1.0.0: planframe/guides/migrating-to-1-0.md
           - Streaming rows: planframe/guides/streaming-rows.md
           - Embedding Frame (composition): planframe/guides/embedding-frame.md
+          - Pydantic bridge: planframe/guides/pydantic-bridge.md
           - PySpark-like API (SparkFrame): planframe/guides/pyspark-like-api.md
           - Pandas-like API (PandasLikeFrame): planframe/guides/pandas-like-api.md
       - Reference:

--- a/packages/planframe/planframe/schema/materialize.py
+++ b/packages/planframe/planframe/schema/materialize.py
@@ -26,10 +26,12 @@ def materialize_dataclass(name: str, schema: Schema) -> type[Any]:
     return deco(cls)
 
 
-def materialize_pydantic(name: str, schema: Schema) -> type[BaseModel]:
+def materialize_pydantic(
+    name: str, schema: Schema, *, base: type[BaseModel] = BaseModel
+) -> type[BaseModel]:
     # Pydantic's `create_model` accepts field definitions as kwargs: name=(type, default).
     field_definitions: dict[str, Any] = {f.name: (f.dtype, ...) for f in schema.fields}
-    return create_model(name, **field_definitions)
+    return create_model(name, __base__=base, **field_definitions)
 
 
 def materialize_model(

--- a/tests/test_materialize_pydantic_base.py
+++ b/tests/test_materialize_pydantic_base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from planframe.schema.ir import Field, Schema
+from planframe.schema.materialize import materialize_pydantic
+
+
+def test_materialize_pydantic_can_inherit_base() -> None:
+    class MyBase(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+    schema = Schema(fields=(Field(name="id", dtype=int), Field(name="name", dtype=str)))
+    Model = materialize_pydantic("Row", schema, base=MyBase)
+
+    assert issubclass(Model, MyBase)
+    out = Model(id=1, name="a")
+    assert out.id == 1


### PR DESCRIPTION
## Summary
- Add `base=` to `materialize_pydantic` so generated models can inherit a user-provided `BaseModel` (config/mixins).
- Add a docs guide with recommended recipes for validating PlanFrame materialization with Pydantic.
- Add a small unit test for the `base=` behavior.

## Test plan
- [x] `ruff check`
- [x] `uv run mkdocs build --strict`
- [x] `pytest tests/test_materialize_pydantic_base.py`

Fixes #81.