### PR TITLE
Adapters: add plan/expr IR version markers and docs

### DIFF
--- a/docs/planframe/design/ir-versioning.md
+++ b/docs/planframe/design/ir-versioning.md
@@ -1,0 +1,76 @@
+# Plan / expression IR versioning (adapter compatibility)
+
+PlanFrame adapters implement:
+
+- **expression compilation** (`BaseAdapter.compile_expr`) over PlanFrame’s expression IR (`planframe.expr`)
+- **plan execution** over PlanFrame’s plan nodes (`planframe.plan.nodes`)
+
+As PlanFrame evolves, third-party adapters need a predictable way to detect when a PlanFrame upgrade may introduce **new IR shapes**.
+
+## Coarse-grained IR versions
+
+PlanFrame exposes two monotonic integer markers:
+
+- `planframe.__plan_ir_version__`
+- `planframe.__expr_ir_version__`
+
+These are intended as a **compatibility guard**, not a full feature matrix.
+
+### When versions bump
+
+The versions bump when an adapter (or external tooling that pattern-matches IR) might reasonably need an update, e.g.:
+
+- a new `PlanNode` or `Expr` node is added
+- an existing node’s fields or semantics change
+- an execution-relevant invariant changes (e.g. a node is reinterpreted)
+
+## How adapters should use this
+
+### Recommended: fail fast with a clear message
+
+If your adapter is pinned to a known set of supported nodes, you can check versions during adapter initialization:
+
+```python
+import planframe
+
+SUPPORTED_PLAN = 1
+SUPPORTED_EXPR = 1
+
+if planframe.__plan_ir_version__ != SUPPORTED_PLAN:
+    raise RuntimeError(
+        f\"Unsupported PlanFrame plan IR version: {planframe.__plan_ir_version__} (expected {SUPPORTED_PLAN})\"
+    )
+
+if planframe.__expr_ir_version__ != SUPPORTED_EXPR:
+    raise RuntimeError(
+        f\"Unsupported PlanFrame expr IR version: {planframe.__expr_ir_version__} (expected {SUPPORTED_EXPR})\"
+    )
+```
+
+If you prefer a looser stance, you can accept a range and rely on runtime `NotImplementedError` for specific nodes. The key is to be explicit and user-friendly.
+
+### Also required: handle unknown nodes
+
+Even with version checks, adapters should still raise clear errors for unsupported shapes:
+
+- unknown `Expr` in `compile_expr` → `NotImplementedError` / adapter-specific error
+- unsupported `PlanNode` semantics → `NotImplementedError` during execution
+
+## Plan `Source.ir_version`
+
+`Source` carries an `ir_version` field. PlanFrame sets it to the current `PLAN_IR_VERSION` when constructing a new `Frame`.
+
+This is useful for:
+
+- **debugging** and “what created this plan?” provenance
+- external tooling that serializes or snapshots plan trees
+
+It is not a substitute for `planframe.__plan_ir_version__` (which is the stable marker adapters should check).
+
+## Adapter release checklist (when PlanFrame adds a new node)
+
+- implement the new IR node handling (compile and/or execute)
+- add conformance tests
+- bump your adapter’s version and document supported PlanFrame versions
+- consider validating `__plan_ir_version__` / `__expr_ir_version__` at import/init time to fail fast
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
           - Package plan: planframe/design/package-plan.md
           - Core layout: planframe/design/core-layout.md
           - Backend adapter design: planframe/design/backend-adapter-design.md
+          - IR versioning (adapters): planframe/design/ir-versioning.md
           - Interface parity (Polars): planframe/design/interface-parity-polars.md
           - Interface parity (pandas): planframe/design/interface-parity-pandas.md
           - Interface parity (Spark): planframe/design/interface-parity-spark.md

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -14,6 +14,7 @@ from planframe.execution import execute_plan
 from planframe.execution_options import ExecutionOptions
 from planframe.frame import Frame
 from planframe.groupby import GroupedFrame
+from planframe.ir_versions import EXPR_IR_VERSION, PLAN_IR_VERSION
 from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
 from planframe.selector import ColumnSelector
@@ -31,6 +32,8 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
+    "__expr_ir_version__",
+    "__plan_ir_version__",
     "Frame",
     "Schema",
     "GroupedFrame",
@@ -43,3 +46,7 @@ __all__ = [
     "spark",
     "pandas",
 ]
+
+# IR compatibility markers for adapter authors and external tooling.
+__plan_ir_version__: int = PLAN_IR_VERSION
+__expr_ir_version__: int = EXPR_IR_VERSION

--- a/packages/planframe/planframe/frame/_mixin_core.py
+++ b/packages/planframe/planframe/frame/_mixin_core.py
@@ -10,6 +10,7 @@ from planframe.backend.errors import PlanFrameBackendError
 from planframe.compile_context import PlanCompileContext
 from planframe.execution import execute_plan
 from planframe.expr.api import Expr
+from planframe.ir_versions import PLAN_IR_VERSION
 from planframe.plan.nodes import JoinKeyColumn, JoinKeyExpr, PlanNode, Source
 from planframe.plan.optimize import optimize_plan
 from planframe.schema.ir import Schema
@@ -88,7 +89,7 @@ class FramePlanMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         return cls(
             _data=data,
             _adapter=adapter,
-            _plan=Source(schema_type=schema, ir_version=1),
+            _plan=Source(schema_type=schema, ir_version=PLAN_IR_VERSION),
             _schema=schema_ir,
         )
 

--- a/packages/planframe/planframe/ir_versions.py
+++ b/packages/planframe/planframe/ir_versions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Versioning for PlanFrame's plan and expression IR.
+
+PlanFrame adapters compile expression IR (`planframe.expr`) and execute plan nodes
+(`planframe.plan.nodes`). Third-party adapters can use these version markers to
+fail predictably when a PlanFrame upgrade introduces new IR shapes they don't yet
+support.
+
+These versions are:
+- **coarse-grained** (single integer per IR family)
+- **monotonic** (only ever increase)
+- intended to be used as a compatibility guard, not as a detailed feature matrix.
+"""
+
+# Plan IR version.
+#
+# Bump when a PlanNode shape changes in a way that a downstream adapter (or external
+# tooling) would need to update to interpret/execute it correctly.
+#
+# Examples:
+# - a new PlanNode is added (downstream adapter that pattern-matches nodes may need updating)
+# - fields on an existing PlanNode are added/removed/renamed or semantics change
+PLAN_IR_VERSION: int = 1
+
+# Expression IR version.
+#
+# Bump when expression node shapes change in a way that affects adapter compilation
+# (e.g. a new Expr node is added, AggExpr changes shape, etc.).
+EXPR_IR_VERSION: int = 1

--- a/tests/test_ir_versions.py
+++ b/tests/test_ir_versions.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import planframe
+
+
+def test_ir_version_markers_exist_and_are_ints() -> None:
+    assert isinstance(planframe.__plan_ir_version__, int)
+    assert isinstance(planframe.__expr_ir_version__, int)
+    assert planframe.__plan_ir_version__ >= 1
+    assert planframe.__expr_ir_version__ >= 1


### PR DESCRIPTION
## Summary
- Add `planframe.__plan_ir_version__` and `planframe.__expr_ir_version__` markers for adapter compatibility checks.
- Centralize IR versions in `planframe.ir_versions` and set `Source.ir_version` from the plan IR version.
- Add a design doc page describing version bump policy and recommended adapter behavior.

## Test plan
- [x] `ruff check`
- [x] `uv run mkdocs build --strict`
- [x] `pytest tests/test_ir_versions.py`

Fixes #82.