### PR TITLE
Packaging: add Homepage Project-URL metadata

### DIFF
--- a/packages/planframe/pyproject.toml
+++ b/packages/planframe/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
  ]
  
  [project.urls]
+Homepage = "https://github.com/eddiethedean/planframe"
 Repository = "https://github.com/eddiethedean/planframe"
 Documentation = "https://planframe.readthedocs.io/en/latest/planframe/"
 Issues = "https://github.com/eddiethedean/planframe/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ classifiers = [
 ]
 dependencies = []
 
+[project.urls]
+Homepage = "https://github.com/eddiethedean/planframe"
+Repository = "https://github.com/eddiethedean/planframe"
+Documentation = "https://planframe.readthedocs.io/en/latest/"
+Issues = "https://github.com/eddiethedean/planframe/issues"
+
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",


### PR DESCRIPTION
## Summary
- Add `Homepage` under `[project.urls]` for the root meta-package and core `planframe` package.
- Ensures built wheels include `Project-URL: Homepage, ...` (and other URLs) for downstream tooling.

## Test plan
- [x] `uv build` and inspected wheel `METADATA` contains `Project-URL: Homepage, ...`

Fixes #95.