### PR TITLE
Typing: add FrameAny alias for adapter ergonomics

### DIFF
--- a/docs/planframe/design/typing-design.md
+++ b/docs/planframe/design/typing-design.md
@@ -247,6 +247,24 @@ To maximize Pyright success, the public typed API should enforce these rules:
 - `lambda`-based apply
 - backend-native raw expressions in typed methods
 
+## 8.1 Adapter/host annotation ergonomics (widening `Frame[...]`)
+
+In downstream adapters and “host types” (composition wrappers), you often want to expose a precise `Frame[SchemaT, BackendFrameT, BackendExprT]` **internally**, but allow users to annotate it more loosely without repeating the exact type arguments everywhere.
+
+Because `Frame[...]` is a generic with invariant parameters (as in most Python type checkers), the recommended pattern is to use a **deliberate widening alias**:
+
+- `planframe.typing.FrameAny` (an alias for `Frame[Any, Any, Any]`)
+
+Example:
+
+```python
+from planframe.typing import FrameAny
+
+def takes_any_frame(x: FrameAny) -> None: ...
+```
+
+This keeps adapter surfaces ergonomic without changing core `Frame` semantics.
+
 ---
 
 ## 9. The Realistic Implementation Model

--- a/packages/planframe/planframe/typing/__init__.py
+++ b/packages/planframe/planframe/typing/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from .frame_aliases import FrameAny as FrameAny
 from .host_frame import HasInnerFrame as HasInnerFrame
 from .scalars import Scalar as Scalar
 from .storage import StorageOptions as StorageOptions
 
-__all__ = ["HasInnerFrame", "Scalar", "StorageOptions"]
+__all__ = ["FrameAny", "HasInnerFrame", "Scalar", "StorageOptions"]

--- a/packages/planframe/planframe/typing/__init__.pyi
+++ b/packages/planframe/planframe/typing/__init__.pyi
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import Any, TypeAlias
+
+from planframe.frame import Frame
+
 from ._schema_types import JoinedSchema as JoinedSchema
 from .host_frame import HasInnerFrame as HasInnerFrame
 from .scalars import Scalar as Scalar
 from .storage import StorageOptions as StorageOptions
 
-__all__ = ["HasInnerFrame", "JoinedSchema", "Scalar", "StorageOptions"]
+FrameAny: TypeAlias = Frame[Any, Any, Any]
+
+__all__ = ["FrameAny", "HasInnerFrame", "JoinedSchema", "Scalar", "StorageOptions"]

--- a/packages/planframe/planframe/typing/frame_aliases.py
+++ b/packages/planframe/planframe/typing/frame_aliases.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    from planframe.frame import Frame
+
+
+# Public helper aliases for adapter authors and host types.
+#
+# These are intentionally defined in a small module to avoid importing `Frame` at runtime
+# (which can create cycles) while still providing stable import paths for type checkers.
+
+FrameAny: TypeAlias = "Frame[Any, Any, Any]"

--- a/packages/planframe/planframe/typing/frame_aliases.pyi
+++ b/packages/planframe/planframe/typing/frame_aliases.pyi
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
+from planframe.frame import Frame
+
+FrameAny = Frame[Any, Any, Any]

--- a/tests/pyright/pass/frame_any_alias.py
+++ b/tests/pyright/pass/frame_any_alias.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from planframe.typing import FrameAny
+from planframe_polars import PolarsFrame
+
+
+@dataclass(frozen=True)
+class User(PolarsFrame):
+    id: int
+    age: int
+
+
+def f(pf: User) -> None:
+    widened: FrameAny = pf
+    _ = widened.select("id")
+    _ = cast(Any, widened).to_dicts()


### PR DESCRIPTION
## Summary
- Add `planframe.typing.FrameAny` as a stable widening alias for `Frame[Any, Any, Any]`.
- Document the recommended annotation strategy for adapters/host types given invariant `Frame[...]` parameters.
- Add a Pyright pass example using `FrameAny`.

## Test plan
- [x] `pyright --project tests/pyright/pyrightconfig.json tests/pyright/pass/frame_any_alias.py`

Fixes #93.