### PR TITLE
Packaging: add planframe.__version__

### DIFF
--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -19,6 +19,27 @@ from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
 from planframe.selector import ColumnSelector
 
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _dist_version
+except Exception:  # pragma: no cover
+    # Very old Pythons; PlanFrame requires 3.10+, but keep import safe.
+    PackageNotFoundError = Exception  # type: ignore[assignment]
+    _dist_version = None  # type: ignore[assignment]
+
+
+def _get_version() -> str:
+    if _dist_version is None:  # pragma: no cover
+        return "0+unknown"
+    try:
+        return _dist_version("planframe")
+    except PackageNotFoundError:
+        # Editable installs or unusual envs may not have dist metadata available.
+        return "0+unknown"
+
+
+__version__: str = _get_version()
+
 
 def __getattr__(name: str) -> Any:
     # Lazily expose `planframe.expr` / `planframe.spark` / `planframe.pandas` to avoid import-time cycles.
@@ -32,6 +53,7 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
+    "__version__",
     "__expr_ir_version__",
     "__plan_ir_version__",
     "Frame",

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -7,6 +7,8 @@ For everything else, prefer importing from the submodules directly.
 from __future__ import annotations
 
 import importlib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from typing import Any
 
 from planframe.dynamic_groupby import DynamicGroupedFrame
@@ -19,18 +21,8 @@ from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
 from planframe.selector import ColumnSelector
 
-try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version as _dist_version
-except Exception:  # pragma: no cover
-    # Very old Pythons; PlanFrame requires 3.10+, but keep import safe.
-    PackageNotFoundError = Exception  # type: ignore[assignment]
-    _dist_version = None  # type: ignore[assignment]
-
 
 def _get_version() -> str:
-    if _dist_version is None:  # pragma: no cover
-        return "0+unknown"
     try:
         return _dist_version("planframe")
     except PackageNotFoundError:

--- a/tests/test_version_attr.py
+++ b/tests/test_version_attr.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import planframe
+
+
+def test_planframe_has_version_attr() -> None:
+    assert isinstance(planframe.__version__, str)
+    assert planframe.__version__


### PR DESCRIPTION
## Summary
- Add `planframe.__version__` populated from `importlib.metadata.version("planframe")` with a safe fallback.
- Add a small regression test asserting the attribute exists and is non-empty.

## Test plan
- [x] `pytest tests/test_version_attr.py`

Fixes #94.