### PR TITLE
feat: publish minimal BaseAdapter conformance kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this repository are documented here.
 - `planframe`, `planframe-polars`, and `planframe-pandas` are released together at the same version.
 - `planframe-sparkless` is versioned independently.
 
+## Unreleased
+
+### Added
+
+- **`planframe.adapter_conformance`**: minimal `run_minimal_adapter_conformance` helper for third-party `BaseAdapter` implementations, plus optional extra **`planframe[adapter-dev]`** (pytest) for adapter author workflows. See the [Adapter conformance kit](https://planframe.readthedocs.io/en/latest/planframe/guides/adapter-conformance/) guide.
+
 ## 1.0.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ source .venv/bin/activate
 pytest
 ```
 
+Third-party adapter authors can run PlanFrame’s **published** minimal conformance helper (`planframe.adapter_conformance`) in their own CI; see the docs: [Adapter conformance kit](https://planframe.readthedocs.io/en/latest/planframe/guides/adapter-conformance/).
+
 Run tests in parallel (optional):
 
 ```bash

--- a/docs/planframe/guides/adapter-conformance.md
+++ b/docs/planframe/guides/adapter-conformance.md
@@ -1,0 +1,80 @@
+# Adapter conformance kit (third-party `BaseAdapter`)
+
+PlanFrame ships a **small, stable** conformance API so adapter authors can get a **pass/fail** signal in CI without copying PlanFrame’s full backend test matrix.
+
+This is a **development aid**, not a “certified for production” claim.
+
+## Install
+
+From PyPI (when using the published `planframe` core package):
+
+```bash
+pip install "planframe[adapter-dev]"
+```
+
+The `adapter-dev` extra pulls in **pytest** (and any other lightweight test helpers we add for adapter authors). The conformance runner itself lives in the core package: `planframe.adapter_conformance`.
+
+## What it checks (MVP)
+
+`run_minimal_adapter_conformance` exercises a short list of **named cases** against *your* `Frame` subclass (the same pattern as `planframe_polars.PolarsFrame`):
+
+| Case | Roughly |
+|------|--------|
+| `select_filter` | `select` + `filter` |
+| `project_expr` | `select` with a computed column (`Expr`) |
+| `sort` | `sort` by a column |
+| `group_by_agg` | `group_by` + tuple reduction agg |
+| `join_inner` | `join` inner on a key (optional; see below) |
+
+If something fails, the raised `AssertionError` (or returned `ConformanceResult`) includes the **case name** so failures are actionable.
+
+## API
+
+```python
+from planframe.adapter_conformance import run_minimal_adapter_conformance
+
+# Your Frame subclasses, e.g. MyFrame({"id": [...], ...})
+run_minimal_adapter_conformance(
+    users=MyUsersFrame,
+    join_left=MyJoinLeftFrame,
+    join_right=MyJoinRightFrame,
+)
+```
+
+- **`users`**: required. Builds a frame whose rows have **`id` (int), `name` (str), `age` (int)** (same idea as the examples throughout PlanFrame docs).
+- **`join_left` / `join_right`**: optional. If either is omitted, the `join_inner` case is **skipped** (reported in `ConformanceResult`, not treated as a failure).
+
+You can pass a **class** with a dict-of-columns constructor, or a **callable** `Mapping[str, Sequence] -> Frame`.
+
+To inspect results without raising:
+
+```python
+result = run_minimal_adapter_conformance(users=MyUsersFrame, raise_on_failure=False)
+assert result.passed
+```
+
+## pytest example (single test)
+
+```python
+# tests/test_planframe_adapter_contract.py
+from planframe.adapter_conformance import run_minimal_adapter_conformance
+from mypkg.frames import Users, JoinLeft, JoinRight
+
+def test_planframe_adapter_contract() -> None:
+    run_minimal_adapter_conformance(users=Users, join_left=JoinLeft, join_right=JoinRight)
+```
+
+## GitHub Actions recipe
+
+Minimal workflow step after installing your package and test deps:
+
+```yaml
+- name: PlanFrame adapter conformance
+  run: pytest -q tests/test_planframe_adapter_contract.py
+```
+
+Use the same interpreter you use for the rest of your tests (the kit only needs `planframe` + your adapter package).
+
+## Relationship to PlanFrame’s own tests
+
+PlanFrame’s repository also uses a `conformance` **pytest marker** for its full backend matrices (Polars, pandas, etc.). Third-party adapters are expected to depend on this **small** `planframe.adapter_conformance` surface rather than vendoring PlanFrame’s internal test suite.

--- a/docs/planframe/guides/creating-an-adapter.md
+++ b/docs/planframe/guides/creating-an-adapter.md
@@ -14,6 +14,8 @@ The adapter API is the abstract base class:
 
 - `packages/planframe/planframe/backend/adapter.py` (`BaseAdapter`)
 
+For a **small, published pass/fail suite** you can run in your own CI (recommended for third-party adapters), see [Adapter conformance kit](adapter-conformance.md).
+
 ### How plans reach your adapter
 
 Chaining on `Frame` records a **`PlanNode`** tree and updates the derived schema. At materialization (`collect`, `to_dicts`, `to_dict`, `write_*`, …), PlanFrame runs **`execute_plan`**, which walks that tree and invokes the matching **`BaseAdapter`** methods. Expression IR is compiled through **`PlanCompileContext`** (`planframe.compile_context`) so the same rules apply when building plans and when executing them. For a file-level map (mixins, dispatch registry, stub location), see [Core layout](../design/core-layout.md).

--- a/docs/planframe/index.md
+++ b/docs/planframe/index.md
@@ -7,6 +7,7 @@ PlanFrame core builds a typed plan and delegates execution to a backend via `Bas
 ## Next steps
 
 - Read the guide: [Creating an adapter](guides/creating-an-adapter.md)
+- **Third-party adapters:** run the minimal CI suite — [Adapter conformance kit](guides/adapter-conformance.md)
 - Learn the row-export APIs: [Streaming rows](guides/streaming-rows.md)
 - Wrapping `Frame` in a host type: [Embedding `Frame` (composition)](guides/embedding-frame.md)
 - Optional **API skins** (typed mixins on `Frame`, no extra backend deps): [PySpark-like API](guides/pyspark-like-api.md), [pandas-like API](guides/pandas-like-api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Overview: planframe/index.md
       - Guides:
           - Creating an adapter: planframe/guides/creating-an-adapter.md
+          - Adapter conformance kit: planframe/guides/adapter-conformance.md
           - Migrating to v1.0.0: planframe/guides/migrating-to-1-0.md
           - Streaming rows: planframe/guides/streaming-rows.md
           - Embedding Frame (composition): planframe/guides/embedding-frame.md

--- a/packages/planframe/README.md
+++ b/packages/planframe/README.md
@@ -12,6 +12,7 @@ Documentation (ReadTheDocs):
 - Design docs: `https://planframe.readthedocs.io/en/latest/planframe/design/`
 - Light API reference: `https://planframe.readthedocs.io/en/latest/planframe/reference/api/`
 - Streaming rows: `https://planframe.readthedocs.io/en/latest/planframe/guides/streaming-rows/`
+- Adapter conformance kit (third-party `BaseAdapter` CI): `https://planframe.readthedocs.io/en/latest/planframe/guides/adapter-conformance/`
 - Optional API skins: [PySpark-like (`planframe.spark`)](https://planframe.readthedocs.io/en/latest/planframe/guides/pyspark-like-api/), [pandas-like (`planframe.pandas`)](https://planframe.readthedocs.io/en/latest/planframe/guides/pandas-like-api/)
 
 ### Install
@@ -31,6 +32,7 @@ pip install planframe
 - `planframe.schema`: schema reflection (dataclass + Pydantic) and materialization
 - `planframe.spark`: optional PySpark-like `SparkFrame` / `Column` / `functions` (import `from planframe.spark import SparkFrame`, or `from planframe import spark`)
 - `planframe.pandas`: optional pandas-like `PandasLikeFrame` / `Series` (import `from planframe.pandas import PandasLikeFrame`, or `from planframe import pandas`); mix with any `Frame` subclass for familiar naming without new backend dependencies
+- `planframe.adapter_conformance`: minimal **`run_minimal_adapter_conformance`** helper for adapter authors; optional extra **`planframe[adapter-dev]`** includes pytest for local runs
 
 ### Common transforms
 

--- a/packages/planframe/planframe/adapter_conformance/__init__.py
+++ b/packages/planframe/planframe/adapter_conformance/__init__.py
@@ -1,0 +1,21 @@
+"""Minimal conformance suite for third-party :class:`~planframe.backend.adapter.BaseAdapter` implementations.
+
+Run :func:`run_minimal_adapter_conformance` from adapter CI to get a pass/fail signal with
+named cases (select/filter, projections, sort, group_by/agg, optional join).
+
+Install optional dev deps: ``pip install planframe[adapter-dev]`` (includes pytest for local runs).
+"""
+
+from __future__ import annotations
+
+from planframe.adapter_conformance.suite import (
+    ConformanceCase,
+    ConformanceResult,
+    run_minimal_adapter_conformance,
+)
+
+__all__ = [
+    "ConformanceCase",
+    "ConformanceResult",
+    "run_minimal_adapter_conformance",
+]

--- a/packages/planframe/planframe/adapter_conformance/suite.py
+++ b/packages/planframe/planframe/adapter_conformance/suite.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar, cast
+
+from planframe.expr import col, eq, lit, mul
+from planframe.frame import Frame
+
+FrameT = TypeVar("FrameT", bound=Frame[Any, Any, Any])
+
+Factory = Callable[[Mapping[str, Sequence[object]]], Frame[Any, Any, Any]]
+
+
+def _as_factory(
+    users: type[Frame[Any, Any, Any]] | Factory,
+) -> Factory:
+    if isinstance(users, type):
+        # Frame subclasses (e.g. PolarsFrame) expose a public dict-of-columns constructor;
+        # static analysis still sees the internal Frame.__init__ signature.
+        ctor = cast(Any, users)
+        return lambda data: ctor(data)
+    return users
+
+
+@dataclass(frozen=True, slots=True)
+class ConformanceCase:
+    """One named check in :func:`run_minimal_adapter_conformance`."""
+
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ConformanceResult:
+    """Outcome of :func:`run_minimal_adapter_conformance`."""
+
+    cases: tuple[ConformanceCase, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(c.ok for c in self.cases)
+
+    @property
+    def failed(self) -> tuple[ConformanceCase, ...]:
+        return tuple(c for c in self.cases if not c.ok)
+
+
+def _norm_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Stable sort for order-insensitive comparisons."""
+
+    def key(r: dict[str, object]) -> tuple[tuple[str, object], ...]:
+        return tuple(sorted(r.items(), key=lambda kv: kv[0]))
+
+    return sorted(rows, key=key)
+
+
+def _assert_rows_equal(
+    got: list[dict[str, object]],
+    expected: list[dict[str, object]],
+    *,
+    ordered: bool,
+) -> None:
+    if ordered:
+        assert got == expected
+    else:
+        assert _norm_rows(got) == _norm_rows(expected)
+
+
+def run_minimal_adapter_conformance(
+    *,
+    users: type[Frame[Any, Any, Any]] | Factory,
+    join_left: type[Frame[Any, Any, Any]] | Factory | None = None,
+    join_right: type[Frame[Any, Any, Any]] | Factory | None = None,
+    raise_on_failure: bool = True,
+) -> ConformanceResult:
+    """Run a small, stable set of checks against a ``Frame`` wired to your adapter.
+
+    This is intended for **third-party** ``BaseAdapter`` implementations: you pass
+    factory callables (or concrete ``Frame`` subclasses with a dict-of-columns
+    constructor, like ``planframe_polars.PolarsFrame``) and get a pass/fail signal
+    with **actionable case names** (select/filter, projections, sort, group_by,
+    optional join).
+
+    Args:
+        users: Builds a frame with columns ``id`` (int), ``name`` (str), ``age`` (int).
+        join_left: Optional. Builds a frame with ``id``, ``name`` for the join case.
+        join_right: Optional. Builds a frame with ``id``, ``city`` for the join case.
+        raise_on_failure: If ``True`` (default), raise ``AssertionError`` aggregating
+            failed case names and details when any check fails.
+
+    Returns:
+        :class:`ConformanceResult` listing each case and whether it passed.
+
+    Raises:
+        AssertionError: When ``raise_on_failure`` is true and one or more cases fail.
+    """
+    make_users = _as_factory(users)
+    cases: list[ConformanceCase] = []
+
+    def _run(name: str, fn: Callable[[], None]) -> None:
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001 — surface as a failed case with traceback context
+            cases.append(ConformanceCase(name=name, ok=False, detail=repr(e)))
+        else:
+            cases.append(ConformanceCase(name=name, ok=True))
+
+    def case_select_filter() -> None:
+        pf = make_users({"id": [1, 2], "name": ["a", "b"], "age": [10, 20]})
+        out = pf.select("id", "name").filter(eq(col("id"), lit(1)))
+        rows = out.to_dicts()
+        _assert_rows_equal(rows, [{"id": 1, "name": "a"}], ordered=True)
+
+    def case_project_expr() -> None:
+        pf = make_users({"id": [1, 2], "name": ["a", "b"], "age": [10, 20]})
+        out = pf.select("id", ("twice_age", mul(col("age"), lit(2))))
+        rows = out.to_dicts()
+        _assert_rows_equal(
+            rows,
+            [{"id": 1, "twice_age": 20}, {"id": 2, "twice_age": 40}],
+            ordered=False,
+        )
+
+    def case_sort() -> None:
+        pf = make_users({"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [30, 10, 20]})
+        out = pf.sort("age")
+        rows = out.to_dicts()
+        assert [r["id"] for r in rows] == [2, 3, 1]
+
+    def case_group_by_agg() -> None:
+        pf = make_users({"id": [1, 1, 2], "name": ["a", "b", "c"], "age": [10, 20, 30]})
+        out = pf.group_by("id").agg(total=("sum", "age"))
+        rows = out.to_dicts()
+        _assert_rows_equal(
+            rows,
+            [{"id": 1, "total": 30}, {"id": 2, "total": 30}],
+            ordered=False,
+        )
+
+    _run("select_filter", case_select_filter)
+    _run("project_expr", case_project_expr)
+    _run("sort", case_sort)
+    _run("group_by_agg", case_group_by_agg)
+
+    if join_left is not None and join_right is not None:
+        make_l = _as_factory(join_left)
+        make_r = _as_factory(join_right)
+
+        def case_join_inner() -> None:
+            left = make_l({"id": [1], "name": ["a"]})
+            right = make_r({"id": [1], "city": ["NY"]})
+            out = left.join(right, on=("id",), how="inner")
+            rows = out.to_dicts()
+            _assert_rows_equal(rows, [{"id": 1, "name": "a", "city": "NY"}], ordered=False)
+
+        _run("join_inner", case_join_inner)
+    else:
+        cases.append(
+            ConformanceCase(
+                name="join_inner",
+                ok=True,
+                detail="skipped (join_left/join_right not provided)",
+            )
+        )
+
+    result = ConformanceResult(cases=tuple(cases))
+    if raise_on_failure and not result.passed:
+        lines = [f"{c.name}: {c.detail}" for c in result.failed]
+        msg = "Adapter conformance failed:\n" + "\n".join(lines)
+        raise AssertionError(msg)
+    return result

--- a/packages/planframe/pyproject.toml
+++ b/packages/planframe/pyproject.toml
@@ -21,7 +21,12 @@ classifiers = [
    "typing-extensions>=4.8",
    "pydantic>=1.10",
  ]
- 
+
+[project.optional-dependencies]
+adapter-dev = [
+  "pytest>=8.0",
+]
+
  [project.urls]
 Homepage = "https://github.com/eddiethedean/planframe"
 Repository = "https://github.com/eddiethedean/planframe"

--- a/tests/test_adapter_conformance_kit_polars.py
+++ b/tests/test_adapter_conformance_kit_polars.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from planframe.adapter_conformance import run_minimal_adapter_conformance
+from planframe_polars import PolarsFrame
+
+pytestmark = pytest.mark.conformance
+
+
+class Users(PolarsFrame):
+    id: int
+    name: str
+    age: int
+
+
+class JoinLeft(PolarsFrame):
+    id: int
+    name: str
+
+
+class JoinRight(PolarsFrame):
+    id: int
+    city: str
+
+
+def test_run_minimal_adapter_conformance_polars() -> None:
+    run_minimal_adapter_conformance(users=Users, join_left=JoinLeft, join_right=JoinRight)
+
+
+def test_run_minimal_adapter_conformance_polars_result() -> None:
+    r = run_minimal_adapter_conformance(
+        users=Users,
+        join_left=JoinLeft,
+        join_right=JoinRight,
+        raise_on_failure=False,
+    )
+    assert r.passed
+    names = {c.name for c in r.cases}
+    assert names == {"select_filter", "project_expr", "sort", "group_by_agg", "join_inner"}
+    assert all(c.ok for c in r.cases)
+
+
+def test_join_optional_skip_reported() -> None:
+    r = run_minimal_adapter_conformance(users=Users, raise_on_failure=False)
+    join_cases = [c for c in r.cases if c.name == "join_inner"]
+    assert len(join_cases) == 1
+    assert join_cases[0].ok is True
+    assert "skipped" in join_cases[0].detail


### PR DESCRIPTION
## Summary
- Add `planframe.adapter_conformance` with `run_minimal_adapter_conformance` — named cases (select/filter, expr projection, sort, group_by/agg, optional inner join) for third-party `BaseAdapter` CI.
- Optional extra **`planframe[adapter-dev]`** (pytest) for adapter authors.
- Documentation: [Adapter conformance kit](docs/planframe/guides/adapter-conformance.md), nav + cross-links; README mentions; CHANGELOG **Unreleased**.
- **Tests**: `tests/test_adapter_conformance_kit_polars.py` (`conformance` marker) exercises the suite against `planframe_polars`.

## Test plan
- `uv pip install -e packages/planframe -e packages/planframe-polars -e packages/planframe-pandas -e packages/planframe-sparkless`
- `pytest -q tests/test_adapter_conformance_kit_polars.py`
- `ruff check`, `ty check`, `mkdocs build --strict`

Closes #85.