### PR TITLE
Adapters: structured capability flags for optional sinks

### DIFF
--- a/packages/planframe-pandas/planframe_pandas/adapter.py
+++ b/packages/planframe-pandas/planframe_pandas/adapter.py
@@ -144,6 +144,15 @@ class PandasAdapter(BaseAdapter[PandasBackendFrame, PandasBackendExpr]):
             explode_outer=False,
             posexplode_outer=True,
             lazy_sample=True,
+            scan_delta=False,
+            read_delta=False,
+            sink_delta=False,
+            read_avro=False,
+            sink_avro=False,
+            read_excel=False,
+            sink_excel=True,
+            read_database_uri=False,
+            sink_database=True,
             storage_options=False,
         )
 

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -132,7 +132,16 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
             explode_outer=False,
             posexplode_outer=False,
             lazy_sample=False,
-            storage_options=False,
+            scan_delta=True,
+            read_delta=True,
+            sink_delta=True,
+            read_avro=True,
+            sink_avro=True,
+            read_excel=True,
+            sink_excel=True,
+            read_database_uri=True,
+            sink_database=True,
+            storage_options=True,
         )
 
     def _collect_df(self, df: PolarsBackendFrame) -> pl.DataFrame:

--- a/packages/planframe-sparkless/planframe_sparkless/adapter.py
+++ b/packages/planframe-sparkless/planframe_sparkless/adapter.py
@@ -7,6 +7,7 @@ from sparkless.sql import functions as F
 from sparkless.sql.window import Window
 
 from planframe.backend.adapter import (
+    AdapterCapabilities,
     BaseAdapter,
     ColumnName,
     Columns,
@@ -30,6 +31,25 @@ SparklessBackendExpr = Any  # runtime type is `builtins.PyColumn`
 
 class SparklessAdapter(BaseAdapter[SparklessBackendFrame, SparklessBackendExpr]):
     name = "sparkless"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        # sparkless adapter currently implements a subset of IO and plan nodes.
+        return AdapterCapabilities(
+            explode_outer=False,
+            posexplode_outer=False,
+            lazy_sample=True,
+            scan_delta=False,
+            read_delta=False,
+            sink_delta=False,
+            read_avro=False,
+            sink_avro=False,
+            read_excel=False,
+            sink_excel=False,
+            read_database_uri=False,
+            sink_database=False,
+            storage_options=False,
+        )
 
     # ---- AdapterReader surface (used by SparklessFrame classmethods) ----
     def scan_parquet(

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -35,9 +35,29 @@ class AdapterCapabilities:
     typed-parity, or explicitly unsupported.
     """
 
+    # ---- Plan node capabilities (transform-time) ----
     explode_outer: bool = False
     posexplode_outer: bool = False
     lazy_sample: bool = False
+
+    # ---- IO capabilities (read/sink surfaces) ----
+    #
+    # These flags are intended to avoid "discovering" missing support only when a sink
+    # or reader method is called. PlanFrame uses them to fail fast with actionable errors.
+    scan_delta: bool = False
+    read_delta: bool = False
+    sink_delta: bool = False
+
+    read_avro: bool = False
+    sink_avro: bool = False
+
+    read_excel: bool = False
+    sink_excel: bool = False
+
+    read_database_uri: bool = False
+    sink_database: bool = False
+
+    # Whether `storage_options=` is accepted on IO methods that expose it.
     storage_options: bool = False
 
 

--- a/packages/planframe/planframe/frame/_mixin_io.py
+++ b/packages/planframe/planframe/frame/_mixin_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Generic, Literal, Protocol, TypeVar
 
+from planframe.backend.adapter import AdapterCapabilities
 from planframe.backend.errors import PlanFrameExecutionError
 from planframe.backend.io import AdapterRowStreamer
 from planframe.execution_options import ExecutionOptions
@@ -377,6 +378,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         storage_options: StorageOptions | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if storage_options is not None and not caps.storage_options:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_parquet does not support storage_options for {self._adapter.name} "
+                    "(capabilities.storage_options=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_parquet(
                 planned,
@@ -400,6 +407,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         storage_options: StorageOptions | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if storage_options is not None and not caps.storage_options:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_csv does not support storage_options for {self._adapter.name} "
+                    "(capabilities.storage_options=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_csv(
                 planned,
@@ -420,6 +433,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         storage_options: StorageOptions | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if storage_options is not None and not caps.storage_options:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_ndjson does not support storage_options for {self._adapter.name} "
+                    "(capabilities.storage_options=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_ndjson(planned, path, storage_options=storage_options)
         except Exception as e:  # noqa: BLE001
@@ -435,6 +454,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         storage_options: StorageOptions | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if storage_options is not None and not caps.storage_options:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_ipc does not support storage_options for {self._adapter.name} "
+                    "(capabilities.storage_options=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_ipc(
                 planned, path, compression=compression, storage_options=storage_options
@@ -453,6 +478,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         engine: str | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if not caps.sink_database:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_database is not supported for {self._adapter.name} "
+                    "(capabilities.sink_database=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_database(
                 planned,
@@ -470,6 +501,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         self: _HasFrameIODeps[BackendFrameT, BackendExprT], path: str, *, worksheet: str = "Sheet1"
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if not caps.sink_excel:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_excel is not supported for {self._adapter.name} "
+                    "(capabilities.sink_excel=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_excel(planned, path, worksheet=worksheet)
         except Exception as e:  # noqa: BLE001
@@ -485,6 +522,17 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         storage_options: StorageOptions | None = None,
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if not caps.sink_delta:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_delta is not supported for {self._adapter.name} "
+                    "(capabilities.sink_delta=False)"
+                )
+            if storage_options is not None and not caps.storage_options:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_delta does not support storage_options for {self._adapter.name} "
+                    "(capabilities.storage_options=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_delta(
                 planned, target, mode=mode, storage_options=storage_options
@@ -502,6 +550,12 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
         name: str = "",
     ) -> None:
         try:
+            caps: AdapterCapabilities = self._adapter.capabilities
+            if not caps.sink_avro:
+                raise PlanFrameExecutionError(
+                    f"Backend sink_avro is not supported for {self._adapter.name} "
+                    "(capabilities.sink_avro=False)"
+                )
             planned = self._eval(self._plan)
             self._adapter.writer.sink_avro(planned, path, compression=compression, name=name)
         except Exception as e:  # noqa: BLE001

--- a/tests/test_adapter_capabilities.py
+++ b/tests/test_adapter_capabilities.py
@@ -10,9 +10,29 @@ def test_adapter_capabilities_are_exposed() -> None:
     assert caps.explode_outer is False
     assert caps.posexplode_outer is False
     assert caps.lazy_sample is False
+    assert caps.scan_delta is True
+    assert caps.read_delta is True
+    assert caps.sink_delta is True
+    assert caps.read_avro is True
+    assert caps.sink_avro is True
+    assert caps.read_excel is True
+    assert caps.sink_excel is True
+    assert caps.read_database_uri is True
+    assert caps.sink_database is True
+    assert caps.storage_options is True
 
     pd = PandasAdapter()
     caps2 = pd.capabilities
     assert caps2.explode_outer is False
     assert caps2.posexplode_outer is True
     assert caps2.lazy_sample is True
+    assert caps2.scan_delta is False
+    assert caps2.read_delta is False
+    assert caps2.sink_delta is False
+    assert caps2.read_avro is False
+    assert caps2.sink_avro is False
+    assert caps2.read_excel is False
+    assert caps2.sink_excel is True
+    assert caps2.read_database_uri is False
+    assert caps2.sink_database is True
+    assert caps2.storage_options is False

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import BaseModel
 
 from planframe.backend.adapter import (
+    AdapterCapabilities,
     BackendAdapter,
     CompiledJoinKey,
     CompiledProjectItem,
@@ -88,6 +89,19 @@ def _spy_agg_reduce(values: list[Any], op: str) -> Any:
 
 class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
     name = "spy"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        # SpyAdapter is a test adapter that implements the legacy write_* surface and
+        # accepts `storage_options` on the relevant sinks.
+        return AdapterCapabilities(
+            lazy_sample=True,
+            sink_delta=True,
+            sink_avro=True,
+            sink_excel=True,
+            sink_database=True,
+            storage_options=True,
+        )
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, Any]] = []


### PR DESCRIPTION
## Summary
- Expand `AdapterCapabilities` with structured flags for optional IO hooks (read/sink surfaces).
- Add fail-fast capability checks in `FrameIOMixin.sink_*` methods so unsupported sinks (or `storage_options`) error before plan evaluation.
- Update built-in adapters (polars/pandas/sparkless) to report supported IO features.

## Test plan
- `uv run pytest -q tests/test_adapter_capabilities.py`
- `uv run pytest -q tests/test_pyright_typing.py`

Closes #84.