### PR TITLE
fix(execution): compile plan expressions with per-step input schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
+  # Run on every push (feature branches included). PRs to main also trigger via pull_request.
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,6 @@ name: Security
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this repository are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **`execute_plan`**: compile expressions (filter predicates, projections, sort keys, join keys, etc.) using each step’s **input** schema from the plan, not the final frame schema—fixes `filter(...).select(...)` when the predicate references columns dropped by the downstream projection ([issue #103](https://github.com/eddiethedean/planframe/issues/103)).
+
 ### Added
 
 - (none yet)

--- a/packages/planframe/planframe/execution.py
+++ b/packages/planframe/planframe/execution.py
@@ -44,6 +44,7 @@ from planframe.plan.nodes import (
     WithColumn,
     WithRowCount,
 )
+from planframe.plan.output_schema import plan_output_schema
 from planframe.schema.ir import Schema
 from planframe.typing.frame_like import FrameLike
 
@@ -51,11 +52,31 @@ BackendFrameT = TypeVar("BackendFrameT")
 BackendExprT = TypeVar("BackendExprT")
 
 
+def _compile_ctx_at_input(
+    adapter: BackendAdapter[BackendFrameT, BackendExprT],
+    node: PlanNode,
+) -> PlanCompileContext[BackendFrameT, BackendExprT]:
+    """Compile expressions as evaluated **on the input rows to** *node* (output of ``node.prev``)."""
+
+    prev = getattr(node, "prev", None)
+    if not isinstance(prev, PlanNode):
+        raise PlanFrameBackendError("Internal error: compile context requires a plan node with .prev")
+    return PlanCompileContext(adapter, plan_output_schema(prev))
+
+
+def _compile_ctx_groupby_source(
+    adapter: BackendAdapter[BackendFrameT, BackendExprT], agg_node: Agg
+) -> PlanCompileContext[BackendFrameT, BackendExprT]:
+    gb = agg_node.prev
+    if not isinstance(gb, GroupBy):
+        raise PlanFrameBackendError("Agg must follow GroupBy")
+    return PlanCompileContext(adapter, plan_output_schema(gb.prev))
+
+
 @dataclass
 class _ExecState(Generic[BackendFrameT, BackendExprT]):
     adapter: BackendAdapter[BackendFrameT, BackendExprT]
     root_data: BackendFrameT
-    ctx: PlanCompileContext[BackendFrameT, BackendExprT]
 
     def evaluate(self, node: object) -> BackendFrameT:
         if not isinstance(node, PlanNode):
@@ -85,7 +106,7 @@ def _handle_project(
 ) -> BackendFrameT:
     assert isinstance(node, Project)
     prev = state.evaluate(node.prev)
-    parts = state.ctx.compile_project_items(node.items)
+    parts = _compile_ctx_at_input(state.adapter, node).compile_project_items(node.items)
     return state.adapter.project(prev, parts)
 
 
@@ -104,7 +125,9 @@ def _handle_with_column(
 ) -> BackendFrameT:
     assert isinstance(node, WithColumn)
     return state.adapter.with_column(
-        state.evaluate(node.prev), node.name, state.ctx.compile_expr(node.expr)
+        state.evaluate(node.prev),
+        node.name,
+        _compile_ctx_at_input(state.adapter, node).compile_expr(node.expr),
     )
 
 
@@ -124,7 +147,10 @@ def _handle_with_row_count(
 
 def _handle_filter(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode) -> BackendFrameT:
     assert isinstance(node, Filter)
-    return state.adapter.filter(state.evaluate(node.prev), state.ctx.compile_expr(node.predicate))
+    return state.adapter.filter(
+        state.evaluate(node.prev),
+        _compile_ctx_at_input(state.adapter, node).compile_expr(node.predicate),
+    )
 
 
 def _handle_hint(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode) -> BackendFrameT:
@@ -135,7 +161,7 @@ def _handle_hint(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode)
 def _handle_sort(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode) -> BackendFrameT:
     assert isinstance(node, Sort)
     prev = state.evaluate(node.prev)
-    compiled = state.ctx.compile_sort_keys(node.keys)
+    compiled = _compile_ctx_at_input(state.adapter, node).compile_sort_keys(node.keys)
     return state.adapter.sort(
         prev,
         compiled,
@@ -177,8 +203,9 @@ def _handle_agg(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode) 
     assert isinstance(node, Agg)
     if not isinstance(node.prev, GroupBy):
         raise PlanFrameBackendError("Agg must follow GroupBy")
-    compiled_keys = state.ctx.compile_join_keys_tuple(node.prev.keys)
-    compiled_aggs = state.ctx.compile_named_aggs(node.named_aggs)
+    gb_ctx = _compile_ctx_groupby_source(state.adapter, node)
+    compiled_keys = gb_ctx.compile_join_keys_tuple(node.prev.keys)
+    compiled_aggs = gb_ctx.compile_named_aggs(node.named_aggs)
     return state.adapter.group_by_agg(
         state.evaluate(node.prev.prev),
         keys=compiled_keys,
@@ -190,7 +217,7 @@ def _handle_dynamic_group_by_agg(
     state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode
 ) -> BackendFrameT:
     assert isinstance(node, DynamicGroupByAgg)
-    compiled_aggs = state.ctx.compile_named_aggs(node.named_aggs)
+    compiled_aggs = _compile_ctx_at_input(state.adapter, node).compile_named_aggs(node.named_aggs)
     return state.adapter.group_by_dynamic_agg(
         state.evaluate(node.prev),
         index_column=node.index_column,
@@ -226,7 +253,9 @@ def _handle_fill_null(
     assert isinstance(node, FillNull)
     prev = state.evaluate(node.prev)
     if node.value is not None and isinstance(node.value, Expr):
-        compiled_value: object | BackendExprT = state.ctx.compile_expr(node.value)
+        compiled_value: object | BackendExprT = _compile_ctx_at_input(
+            state.adapter, node
+        ).compile_expr(node.value)
     else:
         compiled_value = node.value
     return state.adapter.fill_null(prev, compiled_value, node.subset, strategy=node.strategy)
@@ -252,12 +281,17 @@ def _handle_join(state: _ExecState[BackendFrameT, BackendExprT], node: PlanNode)
     if getattr(right_frame._adapter, "name", None) != state.adapter.name:
         raise PlanFrameBackendError("Cannot join frames from different backends")
     right_df = right_frame._eval(right_frame._plan)
+    left_ctx = _compile_ctx_at_input(state.adapter, node)
+    right_schema = getattr(right_frame, "_schema", None)
+    if right_schema is None:
+        raise PlanFrameBackendError("Join node right frame is missing _schema")
+    right_ctx = PlanCompileContext(state.adapter, right_schema)
     if node.left_keys is node.right_keys:
-        compiled = state.ctx.compile_join_keys_tuple(node.left_keys)
+        compiled = left_ctx.compile_join_keys_tuple(node.left_keys)
         lo = ro = compiled
     else:
-        lo = state.ctx.compile_join_keys_tuple(node.left_keys)
-        ro = state.ctx.compile_join_keys_tuple(node.right_keys)
+        lo = left_ctx.compile_join_keys_tuple(node.left_keys)
+        ro = right_ctx.compile_join_keys_tuple(node.right_keys)
     return state.adapter.join(
         left_df,
         right_df,
@@ -434,8 +468,8 @@ def execute_plan(
       `collect=True` is provided.
     """
 
-    ctx = PlanCompileContext(adapter, schema)
-    state = _ExecState(adapter=adapter, root_data=root_data, ctx=ctx)
+    _ = schema  # Public API; compile schemas are derived per plan node via plan_output_schema().
+    state = _ExecState(adapter=adapter, root_data=root_data)
     out = state.evaluate(plan)
     if collect:
         return adapter.collect(out, options=options)

--- a/packages/planframe/planframe/plan/output_schema.py
+++ b/packages/planframe/planframe/plan/output_schema.py
@@ -1,0 +1,294 @@
+"""Derive output :class:`~planframe.schema.ir.Schema` for a :class:`~planframe.plan.nodes.PlanNode` subtree.
+
+Used by :func:`~planframe.execution.execute_plan` so expressions compile against the schema of
+each node's **input** rows (the output of ``node.prev``), not the final frame schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from planframe.backend.errors import PlanFrameSchemaError
+from planframe.expr.api import AggExpr, Expr, infer_dtype
+from planframe.plan.nodes import (
+    Agg,
+    Cast,
+    ConcatHorizontal,
+    ConcatVertical,
+    Drop,
+    DropNulls,
+    DropNullsAll,
+    Duplicated,
+    DynamicGroupByAgg,
+    Explode,
+    FillNull,
+    Filter,
+    GroupBy,
+    Head,
+    Hint,
+    Join,
+    JoinKeyColumn,
+    Melt,
+    Pivot,
+    Posexplode,
+    Project,
+    Rename,
+    RollingAgg,
+    Sample,
+    Select,
+    Slice,
+    Sort,
+    Source,
+    Tail,
+    Unique,
+    Unnest,
+    WithColumn,
+    WithRowCount,
+)
+from planframe.schema.ir import Field, Schema, collect_col_names_in_expr
+from planframe.schema.source import schema_from_type
+
+
+def plan_output_schema(node: Any) -> Schema:
+    """Return the row schema produced after executing *node* (this step's output)."""
+
+    if isinstance(node, Source):
+        return schema_from_type(node.schema_type)
+
+    if isinstance(node, Agg):
+        gb = node.prev
+        if not isinstance(gb, GroupBy):
+            raise PlanFrameSchemaError("Agg must follow GroupBy")
+        return _agg_output_schema(gb, node.named_aggs)
+
+    if isinstance(node, DynamicGroupByAgg):
+        return _dynamic_agg_output_schema(node)
+
+    s_in = plan_output_schema(node.prev)
+    return _apply_unary_step(s_in, node)
+
+
+def _agg_output_schema(gb: GroupBy, named_aggs: dict[str, tuple[str, str] | Expr[Any]]) -> Schema:
+    base = plan_output_schema(gb.prev)
+    out_fields: list[Field] = []
+    for i, k in enumerate(gb.keys):
+        if isinstance(k, JoinKeyColumn):
+            out_fields.append(base.get(k.name))
+        else:
+            out_fields.append(Field(name=f"__pf_g{i}", dtype=infer_dtype(k.expr)))
+
+    fm = base.field_map()
+    for out_name, spec in named_aggs.items():
+        if (
+            isinstance(spec, tuple)
+            and len(spec) == 2
+            and isinstance(spec[0], str)
+            and isinstance(spec[1], str)
+        ):
+            op = spec[0]
+            col = spec[1]
+            base.get(col)
+            dtype: object = object
+            if op in {"count", "n_unique"}:
+                dtype = int
+            out_fields.append(Field(name=out_name, dtype=dtype))
+        elif isinstance(spec, AggExpr):
+            missing = collect_col_names_in_expr(spec.inner).difference(fm.keys())
+            if missing:
+                raise PlanFrameSchemaError(
+                    f"aggregation expression references unknown columns: {sorted(missing)}"
+                )
+            out_fields.append(Field(name=out_name, dtype=infer_dtype(spec)))
+        else:
+            raise PlanFrameSchemaError(
+                "agg expects (op, column_name) tuples or agg_sum/agg_mean/...(...) "
+                f"over an expression, got {type(spec).__name__!r}"
+            )
+
+    return Schema(fields=tuple(out_fields))
+
+
+def _dynamic_agg_output_schema(node: DynamicGroupByAgg) -> Schema:
+    base = plan_output_schema(node.prev)
+    out_fields: list[Field] = []
+    out_fields.append(base.get(node.index_column))
+    if node.by is not None:
+        for c in node.by:
+            out_fields.append(base.get(c))
+
+    fm = base.field_map()
+    for out_name, spec in node.named_aggs.items():
+        if (
+            isinstance(spec, tuple)
+            and len(spec) == 2
+            and isinstance(spec[0], str)
+            and isinstance(spec[1], str)
+        ):
+            op = spec[0]
+            col = spec[1]
+            base.get(col)
+            dtype: object = object
+            if op in {"count", "n_unique"}:
+                dtype = int
+            out_fields.append(Field(name=out_name, dtype=dtype))
+        elif isinstance(spec, AggExpr):
+            missing = collect_col_names_in_expr(spec.inner).difference(fm.keys())
+            if missing:
+                raise PlanFrameSchemaError(
+                    f"aggregation expression references unknown columns: {sorted(missing)}"
+                )
+            out_fields.append(Field(name=out_name, dtype=infer_dtype(spec)))
+        else:
+            raise PlanFrameSchemaError(
+                "agg expects (op, column_name) tuples or agg_sum/agg_mean/...(...) "
+                f"over an expression, got {type(spec).__name__!r}"
+            )
+
+    return Schema(fields=tuple(out_fields))
+
+
+def _apply_unary_step(s_in: Schema, node: Any) -> Schema:
+    if isinstance(
+        node,
+        (
+            Filter,
+            Sort,
+            Unique,
+            DropNulls,
+            DropNullsAll,
+            FillNull,
+            Slice,
+            Head,
+            Tail,
+            ConcatVertical,
+            Sample,
+            Hint,
+        ),
+    ):
+        if isinstance(node, Unique):
+            if node.subset is not None:
+                s_in.select(node.subset)
+            return s_in.unique()
+        if isinstance(node, FillNull):
+            if node.subset is not None:
+                s_in.select(node.subset)
+            return s_in.fill_null()
+        if isinstance(node, DropNulls):
+            if node.subset is not None:
+                s_in.select(node.subset)
+            return s_in.drop_nulls()
+        if isinstance(node, DropNullsAll):
+            if node.subset is not None:
+                s_in.select(node.subset)
+            return s_in.drop_nulls_all()
+        return s_in
+
+    if isinstance(node, Select):
+        return s_in.select(node.columns)
+
+    if isinstance(node, Project):
+        return s_in.project(node.items)
+
+    if isinstance(node, Drop):
+        return s_in.drop(node.columns, strict=node.strict)
+
+    if isinstance(node, Rename):
+        return s_in.rename(node.mapping, strict=node.strict)
+
+    if isinstance(node, WithColumn):
+        dtype = infer_dtype(node.expr)
+        return s_in.with_column(node.name, dtype=dtype)
+
+    if isinstance(node, Cast):
+        return s_in.cast(node.name, node.dtype)
+
+    if isinstance(node, WithRowCount):
+        return s_in.with_row_count(node.name)
+
+    if isinstance(node, Duplicated):
+        if node.subset is not None:
+            s_in.select(node.subset)
+        return s_in.duplicated(out_name=node.out_name)
+
+    if isinstance(node, GroupBy):
+        return s_in
+
+    if isinstance(node, RollingAgg):
+        dtype: object = object
+        if node.op in {"count"}:
+            dtype = int
+        return s_in.with_column(node.out_name, dtype=dtype)
+
+    if isinstance(node, Melt):
+        return s_in.melt(
+            id_vars=node.id_vars,
+            value_vars=node.value_vars,
+            variable_name=node.variable_name,
+            value_name=node.value_name,
+        )
+
+    if isinstance(node, Join):
+        right = cast(Any, node.right)
+        right_schema = getattr(right, "_schema", None)
+        if not isinstance(right_schema, Schema):
+            raise PlanFrameSchemaError("Join right frame must expose a PlanFrame Schema as _schema")
+        if node.how == "cross":
+            return s_in.join_merge_cross(right_schema, suffix=node.suffix)
+        return s_in.join_merge(
+            right_schema,
+            left_on=node.left_keys,
+            right_on=node.right_keys,
+            suffix=node.suffix,
+        )
+
+    if isinstance(node, ConcatHorizontal):
+        other = cast(Any, node.other)
+        other_schema = getattr(other, "_schema", None)
+        if not isinstance(other_schema, Schema):
+            raise PlanFrameSchemaError(
+                "ConcatHorizontal other frame must expose a PlanFrame Schema as _schema"
+            )
+        return Schema(fields=tuple([*s_in.fields, *other_schema.fields]))
+
+    if isinstance(node, Pivot):
+        idx = tuple(node.index)
+        if not idx:
+            raise PlanFrameSchemaError("pivot requires non-empty index")
+        s_in.select(idx)
+        on_name = node.on
+        s_in.get(on_name)
+        value_cols = node.values
+        if not value_cols:
+            raise PlanFrameSchemaError("pivot requires non-empty values")
+        for v in value_cols:
+            s_in.get(v)
+
+        on_columns = node.on_columns
+        if on_columns is not None and node.sort_columns:
+            on_columns = tuple(sorted(on_columns))
+
+        out_fields: list[Field] = [s_in.get(c) for c in idx]
+        if on_columns is not None:
+            if len(value_cols) == 1:
+                for c in on_columns:
+                    out_fields.append(Field(name=str(c), dtype=object))
+            else:
+                for v in value_cols:
+                    for c in on_columns:
+                        out_fields.append(Field(name=f"{v}{node.separator}{c}", dtype=object))
+        return Schema(fields=tuple(out_fields))
+
+    if isinstance(node, Explode):
+        return s_in.explode(node.columns)
+
+    if isinstance(node, Unnest):
+        cols = tuple(it.column for it in node.items)
+        return s_in.unnest(cols)[0]
+
+    if isinstance(node, Posexplode):
+        value_name = node.column if node.value is None else node.value
+        return s_in.posexplode(node.column, pos=node.pos, value=value_name)
+
+    raise PlanFrameSchemaError(
+        f"Unsupported plan node for schema propagation: {type(node).__name__}"
+    )

--- a/tests/test_execute_plan_nodes.py
+++ b/tests/test_execute_plan_nodes.py
@@ -8,6 +8,7 @@ from test_core_lazy_and_schema import SpyAdapter
 
 from planframe.execution import execute_plan
 from planframe.expr import add, col, gt, lit
+from planframe.expr.api import Col
 from planframe.frame import Frame
 from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
@@ -134,6 +135,26 @@ def test_execute_plan_select_project_with_column_cast_filter_sort_slice_head_tai
         "tail",
     ]
     assert res == [{"id2": "computed", "b2": "computed", "x": "computed"}]
+
+
+def test_execute_plan_filter_compiles_predicate_with_input_schema_before_select() -> None:
+    """Regression (GH #103): filter(...).select(...) must compile the predicate using the
+    schema at the filter input, not the projected schema after select.
+    """
+
+    class Adapter(SpyAdapter):
+        def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
+            if schema is not None and isinstance(expr, Col):
+                assert expr.name in schema.names(), (expr.name, schema.names())
+            return super().compile_expr(expr, schema=schema)
+
+    adapter = Adapter()
+    data = [{"id": 1, "a": 1, "b": 2}]
+    pf = Frame.source(data, adapter=adapter, schema=S)
+
+    out = pf.filter(gt(col("b"), lit(0))).select("id")
+    _ = execute_plan(adapter=adapter, plan=out.plan(), root_data=pf._data, schema=out.schema())
+    assert ("filter", gt(col("b"), lit(0))) in adapter.calls
 
 
 def test_execute_plan_unique_and_duplicated() -> None:


### PR DESCRIPTION
Fixes #103.

- Derive compile schemas from the plan via `plan_output_schema()` so `execute_plan` compiles filter predicates and other expressions against each step's input schema, not the final frame schema.
- CI: run workflows on push to any branch (in addition to PRs targeting main).