### PR TITLE
feat(adapter): dtype resolution hook for compile_expr (fixes #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this repository are documented here.
 
 ### Added
 
-- (none yet)
+- **`BaseAdapter.resolve_dtype`**: optional hook for dtype-aware `Col(...)` lowering during `compile_expr`, with **`CompileExprContext`** (exported from `planframe`) carrying the active schema. Polars, pandas, and sparkless adapters invoke the hook for every column reference ([issue #104](https://github.com/eddiethedean/planframe/issues/104)).
 
 ## 1.1.0
 

--- a/docs/planframe/guides/examples/rows_adapter_minimal.py
+++ b/docs/planframe/guides/examples/rows_adapter_minimal.py
@@ -27,7 +27,7 @@ RowsFrame = list[dict[str, object]]
 class RowsAdapter(BaseAdapter[RowsFrame, Expr[object]]):
     name = "rows"
 
-    def compile_expr(self, expr: Expr[object], *, schema: Any = None) -> Expr[object]:
+    def compile_expr(self, expr: Expr[object], *, schema: Any = None, ctx: Any = None) -> Expr[object]:
         return expr
 
     def select(self, df: RowsFrame, columns: tuple[str, ...]) -> RowsFrame:

--- a/packages/planframe-pandas/planframe_pandas/adapter.py
+++ b/packages/planframe-pandas/planframe_pandas/adapter.py
@@ -13,12 +13,14 @@ from planframe.backend.adapter import (
     CompiledJoinKey,
     CompiledProjectItem,
     CompiledSortKey,
+    CompileExprContext,
 )
 from planframe.backend.errors import PlanFrameBackendError
 from planframe.execution_options import ExecutionOptions
 from planframe.expr.api import Expr
 from planframe.plan.join_options import JoinOptions
 from planframe.plan.nodes import UnnestItem
+from planframe.schema.ir import Schema
 from planframe.typing.scalars import Scalar
 from planframe.typing.storage import StorageOptions
 from planframe_pandas.compile_expr import AggExprSpec, PandasExpr, compile_expr
@@ -298,10 +300,21 @@ class PandasAdapter(BaseAdapter[PandasBackendFrame, PandasBackendExpr]):
         )
         return pd.DataFrame({out_name: mask})
 
-    def compile_expr(self, expr: object, *, schema: Any = None) -> PandasBackendExpr:
+    def compile_expr(
+        self,
+        expr: object,
+        *,
+        schema: Schema | None = None,
+        ctx: CompileExprContext | None = None,
+    ) -> PandasBackendExpr:
         if not isinstance(expr, Expr):
             raise TypeError(f"Expected PlanFrame Expr, got {type(expr)!r}")
-        return compile_expr(cast(Expr[Any], expr))
+        if ctx is None:
+            ctx = CompileExprContext(schema=schema)
+        return compile_expr(
+            cast(Expr[Any], expr),
+            dtype_for=lambda n: self.resolve_dtype(n, ctx=ctx),
+        )
 
     def group_by_agg(
         self,

--- a/packages/planframe-pandas/planframe_pandas/compile_expr.py
+++ b/packages/planframe-pandas/planframe_pandas/compile_expr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, TypeAlias, cast
 
@@ -68,11 +69,26 @@ class AggExprSpec:
     inner: PandasExpr
 
 
-def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
+_dtype_hook: ContextVar[Callable[[str], object | None] | None] = ContextVar(
+    "_dtype_hook", default=None
+)
+
+
+def compile_expr(
+    expr: Expr[Any], *, dtype_for: Callable[[str], object | None] | None = None
+) -> PandasExpr | AggExprSpec:
+    tok = _dtype_hook.set(dtype_for)
+    try:
+        return _pe_impl(expr)
+    finally:
+        _dtype_hook.reset(tok)
+
+
+def _pe_impl(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
     """Compile PlanFrame expression IR into a callable pandas expression."""
 
     def _as_expr(e: Expr[Any]) -> PandasExpr:
-        out = compile_expr(e)
+        out = _pe_impl(e)
         if isinstance(out, AggExprSpec):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -80,8 +96,11 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
         return cast(PandasExpr, out)
 
     if isinstance(expr, Alias):
-        return compile_expr(expr.expr)
+        return _pe_impl(expr.expr)
     if isinstance(expr, Col):
+        cb = _dtype_hook.get()
+        if cb is not None:
+            _ = cb(expr.name)
         name = expr.name
         return lambda df: df[name]
     if isinstance(expr, Lit):
@@ -91,14 +110,14 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
     # Aggregations are represented as a wrapper; group_by_agg handles execution.
     if isinstance(expr, AggExpr):
         op = expr.op
-        inner = compile_expr(expr.inner)
+        inner = _pe_impl(expr.inner)
         if isinstance(inner, AggExprSpec):
             raise PlanFrameExpressionError("Nested AggExpr is not supported")
         return AggExprSpec(op=op, inner=cast(PandasExpr, inner))
 
     if isinstance(expr, (Add, Sub, Mul, TrueDiv, Eq, Ne, Lt, Le, Gt, Ge, And, Or)):
-        left = compile_expr(expr.left)
-        right = compile_expr(expr.right)
+        left = _pe_impl(expr.left)
+        right = _pe_impl(expr.right)
         if isinstance(left, AggExprSpec) or isinstance(right, AggExprSpec):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -134,8 +153,8 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
             return lambda df: cast(pd.Series, left_fn(df)) | cast(pd.Series, right_fn(df))
 
     if isinstance(expr, Pow):
-        base = compile_expr(expr.base)
-        exponent = compile_expr(expr.exponent)
+        base = _pe_impl(expr.base)
+        exponent = _pe_impl(expr.exponent)
         if isinstance(base, AggExprSpec) or isinstance(exponent, AggExprSpec):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -145,7 +164,7 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
         return lambda df: cast(Any, base_fn(df)) ** cast(Any, exp_fn(df))
 
     if isinstance(expr, Not):
-        inner = compile_expr(expr.value)
+        inner = _pe_impl(expr.value)
         if isinstance(inner, AggExprSpec):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -154,7 +173,7 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
         return lambda df: ~cast(pd.Series, inner_fn(df))
 
     if isinstance(expr, Coalesce):
-        values = [compile_expr(v) for v in expr.values]
+        values = [_pe_impl(v) for v in expr.values]
         if any(isinstance(v, AggExprSpec) for v in values):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -175,7 +194,7 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
         return _coalesce
 
     if isinstance(expr, IsNull):
-        inner = compile_expr(expr.value)
+        inner = _pe_impl(expr.value)
         if isinstance(inner, AggExprSpec):
             raise PlanFrameExpressionError(
                 "AggExpr is only supported inside group_by(...).agg(...)"
@@ -191,9 +210,9 @@ def compile_expr(expr: Expr[Any]) -> PandasExpr | AggExprSpec:
         return _is_null
 
     if isinstance(expr, IfElse):
-        cond = compile_expr(expr.cond)
-        if_true = compile_expr(expr.then_value)
-        if_false = compile_expr(expr.else_value)
+        cond = _pe_impl(expr.cond)
+        if_true = _pe_impl(expr.then_value)
+        if_false = _pe_impl(expr.else_value)
         if (
             isinstance(cond, AggExprSpec)
             or isinstance(if_true, AggExprSpec)

--- a/packages/planframe-polars/planframe_polars/adapter.py
+++ b/packages/planframe-polars/planframe_polars/adapter.py
@@ -13,12 +13,14 @@ from planframe.backend.adapter import (
     CompiledJoinKey,
     CompiledProjectItem,
     CompiledSortKey,
+    CompileExprContext,
 )
 from planframe.backend.errors import PlanFrameBackendError
 from planframe.execution_options import ExecutionOptions
 from planframe.expr.api import Expr
 from planframe.plan.join_options import JoinOptions
 from planframe.plan.nodes import UnnestItem
+from planframe.schema.ir import Schema
 from planframe.typing.scalars import Scalar
 from planframe.typing.storage import StorageOptions
 from planframe_polars.compile_expr import compile_expr
@@ -253,10 +255,21 @@ class PolarsAdapter(BaseAdapter[PolarsBackendFrame, pl.Expr]):
         mask = df.select(mask_expr.alias(out_name))[out_name]
         return pl.DataFrame({out_name: mask})
 
-    def compile_expr(self, expr: object, *, schema: Any = None) -> pl.Expr:
+    def compile_expr(
+        self,
+        expr: object,
+        *,
+        schema: Schema | None = None,
+        ctx: CompileExprContext | None = None,
+    ) -> pl.Expr:
         if not isinstance(expr, Expr):
             raise TypeError(f"Expected PlanFrame Expr, got {type(expr)!r}")
-        return compile_expr(expr)
+        if ctx is None:
+            ctx = CompileExprContext(schema=schema)
+        return compile_expr(
+            expr,
+            dtype_for=lambda n: self.resolve_dtype(n, ctx=ctx),
+        )
 
     def group_by_agg(
         self,

--- a/packages/planframe-polars/planframe_polars/compile_expr.py
+++ b/packages/planframe-polars/planframe_polars/compile_expr.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextvars import ContextVar
 from typing import Any, Literal, cast
 
 import polars as pl
@@ -56,67 +58,84 @@ from planframe.expr.api import (
     Xor,
 )
 
+_dtype_hook: ContextVar[Callable[[str], object | None] | None] = ContextVar(
+    "_dtype_hook", default=None
+)
 
-def compile_expr(expr: Expr[Any]) -> pl.Expr:
+
+def compile_expr(
+    expr: Expr[Any], *, dtype_for: Callable[[str], object | None] | None = None
+) -> pl.Expr:
+    tok = _dtype_hook.set(dtype_for)
+    try:
+        return _compile_expr(expr)
+    finally:
+        _dtype_hook.reset(tok)
+
+
+def _compile_expr(expr: Expr[Any]) -> pl.Expr:
     if isinstance(expr, Alias):
-        return compile_expr(expr.expr)
+        return _compile_expr(expr.expr)
     if isinstance(expr, Col):
+        cb = _dtype_hook.get()
+        if cb is not None:
+            _ = cb(expr.name)
         return pl.col(expr.name)
     if isinstance(expr, Lit):
         return pl.lit(expr.value)
     if isinstance(expr, Add):
-        return compile_expr(expr.left) + compile_expr(expr.right)
+        return _compile_expr(expr.left) + _compile_expr(expr.right)
     if isinstance(expr, Sub):
-        return compile_expr(expr.left) - compile_expr(expr.right)
+        return _compile_expr(expr.left) - _compile_expr(expr.right)
     if isinstance(expr, Mul):
-        return compile_expr(expr.left) * compile_expr(expr.right)
+        return _compile_expr(expr.left) * _compile_expr(expr.right)
     if isinstance(expr, TrueDiv):
-        return compile_expr(expr.left) / compile_expr(expr.right)
+        return _compile_expr(expr.left) / _compile_expr(expr.right)
     if isinstance(expr, Eq):
-        return compile_expr(expr.left) == compile_expr(expr.right)
+        return _compile_expr(expr.left) == _compile_expr(expr.right)
     if isinstance(expr, Ne):
-        return compile_expr(expr.left) != compile_expr(expr.right)
+        return _compile_expr(expr.left) != _compile_expr(expr.right)
     if isinstance(expr, Lt):
-        return compile_expr(expr.left) < compile_expr(expr.right)
+        return _compile_expr(expr.left) < _compile_expr(expr.right)
     if isinstance(expr, Le):
-        return compile_expr(expr.left) <= compile_expr(expr.right)
+        return _compile_expr(expr.left) <= _compile_expr(expr.right)
     if isinstance(expr, Gt):
-        return compile_expr(expr.left) > compile_expr(expr.right)
+        return _compile_expr(expr.left) > _compile_expr(expr.right)
     if isinstance(expr, Ge):
-        return compile_expr(expr.left) >= compile_expr(expr.right)
+        return _compile_expr(expr.left) >= _compile_expr(expr.right)
     if isinstance(expr, IsNull):
-        return compile_expr(expr.value).is_null()
+        return _compile_expr(expr.value).is_null()
     if isinstance(expr, IsNotNull):
-        return compile_expr(expr.value).is_not_null()
+        return _compile_expr(expr.value).is_not_null()
     if isinstance(expr, IsIn):
-        return compile_expr(expr.value).is_in(list(expr.options))
+        return _compile_expr(expr.value).is_in(list(expr.options))
     if isinstance(expr, And):
-        return compile_expr(expr.left) & compile_expr(expr.right)
+        return _compile_expr(expr.left) & _compile_expr(expr.right)
     if isinstance(expr, Or):
-        return compile_expr(expr.left) | compile_expr(expr.right)
+        return _compile_expr(expr.left) | _compile_expr(expr.right)
     if isinstance(expr, Not):
-        return ~compile_expr(expr.value)
+        return ~_compile_expr(expr.value)
     if isinstance(expr, Xor):
-        return compile_expr(expr.left) ^ compile_expr(expr.right)
+        return _compile_expr(expr.left) ^ _compile_expr(expr.right)
     if isinstance(expr, Abs):
-        return compile_expr(expr.value).abs()
+        return _compile_expr(expr.value).abs()
     if isinstance(expr, Round):
-        e = compile_expr(expr.value)
+        e = _compile_expr(expr.value)
         return e.round(expr.ndigits) if expr.ndigits is not None else e.round()
     if isinstance(expr, Floor):
-        return compile_expr(expr.value).floor()
+        return _compile_expr(expr.value).floor()
     if isinstance(expr, Ceil):
-        return compile_expr(expr.value).ceil()
+        return _compile_expr(expr.value).ceil()
     if isinstance(expr, Coalesce):
-        return pl.coalesce([compile_expr(v) for v in expr.values])
+        return pl.coalesce([_compile_expr(v) for v in expr.values])
     if isinstance(expr, IfElse):
         return (
-            pl.when(compile_expr(expr.cond))
-            .then(compile_expr(expr.then_value))
-            .otherwise(compile_expr(expr.else_value))
+            pl.when(_compile_expr(expr.cond))
+            .then(_compile_expr(expr.then_value))
+            .otherwise(_compile_expr(expr.else_value))
         )
     if isinstance(expr, Over):
-        e = compile_expr(expr.value)
+        e = _compile_expr(expr.value)
         return e.over(
             partition_by=list(expr.partition_by),
             order_by=(list(expr.order_by) if expr.order_by is not None else None),
@@ -126,61 +145,61 @@ def compile_expr(expr: Expr[Any]) -> pl.Expr:
         if expr.closed not in allowed_closed:
             raise ValueError(f"Unsupported closed interval: {expr.closed!r}")
         closed_lit = cast(Literal["left", "right", "both", "none"], expr.closed)
-        return compile_expr(expr.value).is_between(
-            compile_expr(expr.low),
-            compile_expr(expr.high),
+        return _compile_expr(expr.value).is_between(
+            _compile_expr(expr.low),
+            _compile_expr(expr.high),
             closed=closed_lit,
         )
     if isinstance(expr, Clip):
-        e = compile_expr(expr.value)
-        lower = compile_expr(expr.lower) if expr.lower is not None else None
-        upper = compile_expr(expr.upper) if expr.upper is not None else None
+        e = _compile_expr(expr.value)
+        lower = _compile_expr(expr.lower) if expr.lower is not None else None
+        upper = _compile_expr(expr.upper) if expr.upper is not None else None
         return e.clip(lower_bound=lower, upper_bound=upper)
     if isinstance(expr, Pow):
-        return compile_expr(expr.base) ** compile_expr(expr.exponent)
+        return _compile_expr(expr.base) ** _compile_expr(expr.exponent)
     if isinstance(expr, Exp):
-        return compile_expr(expr.value).exp()
+        return _compile_expr(expr.value).exp()
     if isinstance(expr, Log):
-        return compile_expr(expr.value).log()
+        return _compile_expr(expr.value).log()
     if isinstance(expr, StrContains):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.contains(expr.pattern, literal=expr.literal)
     if isinstance(expr, StrStartsWith):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.starts_with(expr.prefix)
     if isinstance(expr, StrEndsWith):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.ends_with(expr.suffix)
     if isinstance(expr, StrLower):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.to_lowercase()
     if isinstance(expr, StrUpper):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.to_uppercase()
     if isinstance(expr, StrLen):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.len_chars()
     if isinstance(expr, StrReplace):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.replace_all(expr.pattern, expr.replacement, literal=expr.literal)
     if isinstance(expr, StrStrip):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.strip_chars()
     if isinstance(expr, StrSplit):
-        e = compile_expr(expr.value).cast(pl.Utf8)
+        e = _compile_expr(expr.value).cast(pl.Utf8)
         return e.str.split(expr.by)
     if isinstance(expr, DtYear):
-        return compile_expr(expr.value).dt.year()
+        return _compile_expr(expr.value).dt.year()
     if isinstance(expr, DtMonth):
-        return compile_expr(expr.value).dt.month()
+        return _compile_expr(expr.value).dt.month()
     if isinstance(expr, DtDay):
-        return compile_expr(expr.value).dt.day()
+        return _compile_expr(expr.value).dt.day()
     if isinstance(expr, Sqrt):
-        return compile_expr(expr.value).sqrt()
+        return _compile_expr(expr.value).sqrt()
     if isinstance(expr, IsFinite):
-        return compile_expr(expr.value).is_finite()
+        return _compile_expr(expr.value).is_finite()
     if isinstance(expr, AggExpr):
-        inner = compile_expr(expr.inner)
+        inner = _compile_expr(expr.inner)
         if expr.op == "count":
             return inner.count()
         if expr.op == "sum":

--- a/packages/planframe-sparkless/planframe_sparkless/adapter.py
+++ b/packages/planframe-sparkless/planframe_sparkless/adapter.py
@@ -14,6 +14,7 @@ from planframe.backend.adapter import (
     CompiledJoinKey,
     CompiledProjectItem,
     CompiledSortKey,
+    CompileExprContext,
 )
 from planframe.backend.errors import PlanFrameBackendError, PlanFrameExpressionError
 from planframe.execution_options import ExecutionOptions
@@ -562,14 +563,24 @@ class SparklessAdapter(BaseAdapter[SparklessBackendFrame, SparklessBackendExpr])
         return df.sample(withReplacement=with_replacement, fraction=frac, seed=seed)
 
     # ---- Expression compilation + materialization ----
-    def compile_expr(self, expr: object, *, schema: Schema | None = None) -> SparklessBackendExpr:
-        _ = schema
+    def compile_expr(
+        self,
+        expr: object,
+        *,
+        schema: Schema | None = None,
+        ctx: CompileExprContext | None = None,
+    ) -> SparklessBackendExpr:
+        if ctx is None:
+            ctx = CompileExprContext(schema=schema)
         if isinstance(expr, object) and hasattr(expr, "__class__"):
             # PlanFrame Expr nodes are dataclasses; compile using our mapping.
             from planframe.expr.api import Expr as PFExpr
 
             if isinstance(expr, PFExpr):
-                return compile_expr(cast(Any, expr))
+                return compile_expr(
+                    cast(Any, expr),
+                    dtype_for=lambda n: self.resolve_dtype(n, ctx=ctx),
+                )
         raise PlanFrameExpressionError(f"Unsupported expr type for sparkless: {type(expr)!r}")
 
     def collect(

--- a/packages/planframe-sparkless/planframe_sparkless/compile_expr.py
+++ b/packages/planframe-sparkless/planframe_sparkless/compile_expr.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextvars import ContextVar
 from typing import Any, cast
 
 from sparkless.sql import functions as F
@@ -56,62 +58,79 @@ from planframe.expr.api import (
     Xor,
 )
 
+_dtype_hook: ContextVar[Callable[[str], object | None] | None] = ContextVar(
+    "_dtype_hook", default=None
+)
 
-def compile_expr(expr: Expr[Any]) -> Any:
+
+def compile_expr(
+    expr: Expr[Any], *, dtype_for: Callable[[str], object | None] | None = None
+) -> Any:
+    tok = _dtype_hook.set(dtype_for)
+    try:
+        return _sl_compile(expr)
+    finally:
+        _dtype_hook.reset(tok)
+
+
+def _sl_compile(expr: Expr[Any]) -> Any:
     if isinstance(expr, Alias):
-        return compile_expr(expr.expr)
+        return _sl_compile(expr.expr)
     if isinstance(expr, Col):
+        cb = _dtype_hook.get()
+        if cb is not None:
+            _ = cb(expr.name)
         return F.col(expr.name)
     if isinstance(expr, Lit):
         return F.lit(expr.value)
     if isinstance(expr, Add):
-        return compile_expr(expr.left) + compile_expr(expr.right)
+        return _sl_compile(expr.left) + _sl_compile(expr.right)
     if isinstance(expr, Sub):
-        return compile_expr(expr.left) - compile_expr(expr.right)
+        return _sl_compile(expr.left) - _sl_compile(expr.right)
     if isinstance(expr, Mul):
-        return compile_expr(expr.left) * compile_expr(expr.right)
+        return _sl_compile(expr.left) * _sl_compile(expr.right)
     if isinstance(expr, TrueDiv):
-        return compile_expr(expr.left) / compile_expr(expr.right)
+        return _sl_compile(expr.left) / _sl_compile(expr.right)
     if isinstance(expr, Eq):
-        return compile_expr(expr.left) == compile_expr(expr.right)
+        return _sl_compile(expr.left) == _sl_compile(expr.right)
     if isinstance(expr, Ne):
-        return compile_expr(expr.left) != compile_expr(expr.right)
+        return _sl_compile(expr.left) != _sl_compile(expr.right)
     if isinstance(expr, Lt):
-        return compile_expr(expr.left) < compile_expr(expr.right)
+        return _sl_compile(expr.left) < _sl_compile(expr.right)
     if isinstance(expr, Le):
-        return compile_expr(expr.left) <= compile_expr(expr.right)
+        return _sl_compile(expr.left) <= _sl_compile(expr.right)
     if isinstance(expr, Gt):
-        return compile_expr(expr.left) > compile_expr(expr.right)
+        return _sl_compile(expr.left) > _sl_compile(expr.right)
     if isinstance(expr, Ge):
-        return compile_expr(expr.left) >= compile_expr(expr.right)
+        return _sl_compile(expr.left) >= _sl_compile(expr.right)
     if isinstance(expr, IsNull):
-        return compile_expr(expr.value).isNull()
+        return _sl_compile(expr.value).isNull()
     if isinstance(expr, IsNotNull):
-        return compile_expr(expr.value).isNotNull()
+        return _sl_compile(expr.value).isNotNull()
     if isinstance(expr, IsIn):
-        return compile_expr(expr.value).isin(list(expr.options))
+        return _sl_compile(expr.value).isin(list(expr.options))
     if isinstance(expr, And):
-        return compile_expr(expr.left) & compile_expr(expr.right)
+        return _sl_compile(expr.left) & _sl_compile(expr.right)
     if isinstance(expr, Or):
-        return compile_expr(expr.left) | compile_expr(expr.right)
+        return _sl_compile(expr.left) | _sl_compile(expr.right)
     if isinstance(expr, Not):
-        return ~compile_expr(expr.value)
+        return ~_sl_compile(expr.value)
     if isinstance(expr, Xor):
-        return compile_expr(expr.left) ^ compile_expr(expr.right)
+        return _sl_compile(expr.left) ^ _sl_compile(expr.right)
     if isinstance(expr, Abs):
-        return F.abs(compile_expr(expr.value))
+        return F.abs(_sl_compile(expr.value))
     if isinstance(expr, Round):
-        e = compile_expr(expr.value)
+        e = _sl_compile(expr.value)
         return F.round(e, expr.ndigits) if expr.ndigits is not None else F.round(e)
     if isinstance(expr, Floor):
-        return F.floor(compile_expr(expr.value))
+        return F.floor(_sl_compile(expr.value))
     if isinstance(expr, Ceil):
-        return F.ceil(compile_expr(expr.value))
+        return F.ceil(_sl_compile(expr.value))
     if isinstance(expr, Coalesce):
-        return F.coalesce(*[compile_expr(v) for v in expr.values])
+        return F.coalesce(*[_sl_compile(v) for v in expr.values])
     if isinstance(expr, IfElse):
-        return F.when(compile_expr(expr.cond), compile_expr(expr.then_value)).otherwise(
-            compile_expr(expr.else_value)
+        return F.when(_sl_compile(expr.cond), _sl_compile(expr.then_value)).otherwise(
+            _sl_compile(expr.else_value)
         )
     if isinstance(expr, Over):
         # PlanFrame Over only carries partition/order column names, so we can map to Window.
@@ -120,57 +139,57 @@ def compile_expr(expr: Expr[Any]) -> Any:
         w = Window.partitionBy(*expr.partition_by)
         if expr.order_by is not None:
             w = w.orderBy(*expr.order_by)
-        return compile_expr(expr.value).over(w)
+        return _sl_compile(expr.value).over(w)
     if isinstance(expr, Between):
-        return compile_expr(expr.value).between(compile_expr(expr.low), compile_expr(expr.high))
+        return _sl_compile(expr.value).between(_sl_compile(expr.low), _sl_compile(expr.high))
     if isinstance(expr, Clip):
-        e = compile_expr(expr.value)
+        e = _sl_compile(expr.value)
         if expr.lower is not None:
-            e = F.greatest(e, compile_expr(expr.lower))
+            e = F.greatest(e, _sl_compile(expr.lower))
         if expr.upper is not None:
-            e = F.least(e, compile_expr(expr.upper))
+            e = F.least(e, _sl_compile(expr.upper))
         return e
     if isinstance(expr, Pow):
-        return F.pow(compile_expr(expr.base), compile_expr(expr.exponent))
+        return F.pow(_sl_compile(expr.base), _sl_compile(expr.exponent))
     if isinstance(expr, Exp):
-        return F.exp(compile_expr(expr.value))
+        return F.exp(_sl_compile(expr.value))
     if isinstance(expr, Log):
-        return F.log(compile_expr(expr.value))
+        return F.log(_sl_compile(expr.value))
     if isinstance(expr, StrContains):
-        e = compile_expr(expr.value)
+        e = _sl_compile(expr.value)
         if expr.literal:
             return e.contains(expr.pattern)
         return e.rlike(expr.pattern)
     if isinstance(expr, StrStartsWith):
-        return compile_expr(expr.value).startswith(expr.prefix)
+        return _sl_compile(expr.value).startswith(expr.prefix)
     if isinstance(expr, StrEndsWith):
-        return compile_expr(expr.value).endswith(expr.suffix)
+        return _sl_compile(expr.value).endswith(expr.suffix)
     if isinstance(expr, StrLower):
-        return F.lower(compile_expr(expr.value))
+        return F.lower(_sl_compile(expr.value))
     if isinstance(expr, StrUpper):
-        return F.upper(compile_expr(expr.value))
+        return F.upper(_sl_compile(expr.value))
     if isinstance(expr, StrLen):
-        return F.length(compile_expr(expr.value))
+        return F.length(_sl_compile(expr.value))
     if isinstance(expr, StrReplace):
-        return F.regexp_replace(compile_expr(expr.value), expr.pattern, expr.replacement)
+        return F.regexp_replace(_sl_compile(expr.value), expr.pattern, expr.replacement)
     if isinstance(expr, StrStrip):
-        return F.trim(compile_expr(expr.value))
+        return F.trim(_sl_compile(expr.value))
     if isinstance(expr, StrSplit):
-        return F.split(compile_expr(expr.value), expr.by)
+        return F.split(_sl_compile(expr.value), expr.by)
     if isinstance(expr, DtYear):
-        return F.year(compile_expr(expr.value))
+        return F.year(_sl_compile(expr.value))
     if isinstance(expr, DtMonth):
-        return F.month(compile_expr(expr.value))
+        return F.month(_sl_compile(expr.value))
     if isinstance(expr, DtDay):
-        return F.dayofmonth(compile_expr(expr.value))
+        return F.dayofmonth(_sl_compile(expr.value))
     if isinstance(expr, Sqrt):
-        return F.sqrt(compile_expr(expr.value))
+        return F.sqrt(_sl_compile(expr.value))
     if isinstance(expr, IsFinite):
         # Spark doesn't have a direct isFinite; approximate via isnan/isnull checks.
-        e = compile_expr(expr.value)
+        e = _sl_compile(expr.value)
         return (~cast(Any, F.isnan(e))) & e.isNotNull()
     if isinstance(expr, AggExpr):
-        inner = compile_expr(expr.inner)
+        inner = _sl_compile(expr.inner)
         if expr.op == "count":
             return F.count(inner)
         if expr.op == "sum":

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -11,6 +11,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _dist_version
 from typing import Any
 
+from planframe.backend.adapter import CompileExprContext
 from planframe.dynamic_groupby import DynamicGroupedFrame
 from planframe.execution import execute_plan
 from planframe.execution_options import ExecutionOptions
@@ -48,6 +49,7 @@ __all__ = [
     "__version__",
     "__expr_ir_version__",
     "__plan_ir_version__",
+    "CompileExprContext",
     "Frame",
     "Schema",
     "GroupedFrame",

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -27,6 +27,17 @@ AggSpec: TypeAlias = tuple[str, ColumnName] | BackendExprT
 
 
 @dataclass(frozen=True, slots=True)
+class CompileExprContext:
+    """Context passed to :meth:`BaseAdapter.compile_expr` and :meth:`BaseAdapter.resolve_dtype`.
+
+    *schema* is the PlanFrame :class:`~planframe.schema.ir.Schema` for the current plan step
+    (the row shape expressions are compiled against).
+    """
+
+    schema: Schema | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class AdapterCapabilities:
     """Optional backend capability flags.
 
@@ -765,8 +776,29 @@ class BaseAdapter(ABC, Generic[BackendFrameT, BackendExprT]):
         seed: int | None = None,
     ) -> BackendFrameT: ...
 
+    def resolve_dtype(self, name: str, *, ctx: CompileExprContext) -> object | None:
+        """Return the PlanFrame field dtype for *name*, or ``None`` if unknown.
+
+        Invoked when lowering :class:`~planframe.expr.api.Col` during :meth:`compile_expr`.
+        Override when *ctx.schema* is partial (e.g. projected) and dtypes must be recovered
+        from backend metadata or a wider known schema.
+        """
+
+        if ctx.schema is None:
+            return None
+        fm = ctx.schema.field_map()
+        if name in fm:
+            return fm[name].dtype
+        return None
+
     @abstractmethod
-    def compile_expr(self, expr: object, *, schema: Schema | None = None) -> BackendExprT: ...
+    def compile_expr(
+        self,
+        expr: object,
+        *,
+        schema: Schema | None = None,
+        ctx: CompileExprContext | None = None,
+    ) -> BackendExprT: ...
 
     @abstractmethod
     def collect(

--- a/packages/planframe/planframe/compile_context.py
+++ b/packages/planframe/planframe/compile_context.py
@@ -9,6 +9,7 @@ from planframe.backend.adapter import (
     CompiledJoinKey,
     CompiledProjectItem,
     CompiledSortKey,
+    CompileExprContext,
 )
 from planframe.backend.errors import PlanFrameBackendError
 from planframe.expr.api import Expr
@@ -41,7 +42,8 @@ class PlanCompileContext(Generic[BackendFrameT, BackendExprT]):
 
     def compile_expr(self, expr: object) -> BackendExprT:
         try:
-            return self._adapter.compile_expr(expr, schema=self._schema)
+            ctx = CompileExprContext(schema=self._schema)
+            return self._adapter.compile_expr(expr, schema=self._schema, ctx=ctx)
         except Exception as e:  # noqa: BLE001
             raise PlanFrameBackendError(
                 f"Failed to compile expression for backend {self._adapter.name}"

--- a/tests/test_adapter_async_io_defaults.py
+++ b/tests/test_adapter_async_io_defaults.py
@@ -183,8 +183,8 @@ class _AsyncIODefaultsAdapter(BaseAdapter[list[dict[str, Any]], object]):
     def sample(self, df: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
         return df
 
-    def compile_expr(self, expr: object, *, schema: object | None = None) -> object:
-        _ = expr, schema
+    def compile_expr(self, expr: object, *, schema: object | None = None, ctx: object | None = None) -> object:
+        _ = expr, schema, ctx
         return expr
 
     def collect(

--- a/tests/test_core_lazy_and_schema.py
+++ b/tests/test_core_lazy_and_schema.py
@@ -13,6 +13,7 @@ from planframe.backend.adapter import (
     CompiledJoinKey,
     CompiledProjectItem,
     CompiledSortKey,
+    CompileExprContext,
 )
 from planframe.backend.errors import (
     PlanFrameBackendError,
@@ -179,7 +180,12 @@ class SpyAdapter(BackendAdapter[list[dict[str, Any]], object]):
         self.calls.append(("filter", predicate))
         return df[:1]
 
-    def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
+    def compile_expr(self, expr: Any, *, schema: Any = None, ctx: Any = None) -> object:
+        if ctx is None:
+            ctx = CompileExprContext(schema=schema)
+        if isinstance(expr, Expr):
+            for n in collect_col_names_in_expr(expr):
+                self.resolve_dtype(n, ctx=ctx)
         self.calls.append(("compile_expr", (type(expr).__name__, schema is not None)))
         return expr
 
@@ -1631,10 +1637,10 @@ def test_write_methods_execute_and_are_boundaries(tmp_path: Any) -> None:
 
 def test_backend_compile_expr_type_guard() -> None:
     class StrictAdapter(SpyAdapter):
-        def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
+        def compile_expr(self, expr: Any, *, schema: Any = None, ctx: Any = None) -> object:
             if not isinstance(expr, Expr):
                 raise TypeError("Expected Expr")
-            return super().compile_expr(expr, schema=schema)
+            return super().compile_expr(expr, schema=schema, ctx=ctx)
 
     adapter = StrictAdapter()
     pf = Frame.source([{"id": 1, "age": 2}], adapter=adapter, schema=UserDC)

--- a/tests/test_execute_plan_nodes.py
+++ b/tests/test_execute_plan_nodes.py
@@ -143,10 +143,10 @@ def test_execute_plan_filter_compiles_predicate_with_input_schema_before_select(
     """
 
     class Adapter(SpyAdapter):
-        def compile_expr(self, expr: Any, *, schema: Any = None) -> object:
+        def compile_expr(self, expr: Any, *, schema: Any = None, ctx: Any = None) -> object:
             if schema is not None and isinstance(expr, Col):
                 assert expr.name in schema.names(), (expr.name, schema.names())
-            return super().compile_expr(expr, schema=schema)
+            return super().compile_expr(expr, schema=schema, ctx=ctx)
 
     adapter = Adapter()
     data = [{"id": 1, "a": 1, "b": 2}]

--- a/tests/test_frame_api_coverage.py
+++ b/tests/test_frame_api_coverage.py
@@ -194,7 +194,7 @@ def test_frame_error_wrapping_for_collect_to_dicts_and_write() -> None:
         pf3.sink_csv("x.csv")
 
     class BoomCompileAdapter(SpyAdapter):
-        def compile_expr(self, expr: object, *, schema: object = None) -> object:  # type: ignore[override]
+        def compile_expr(self, expr: object, *, schema: object = None, ctx: object = None) -> object:  # type: ignore[override]
             raise RuntimeError("boom")
 
     pf4 = Frame.source([{"id": 1, "name": "a", "age": 2}], adapter=BoomCompileAdapter(), schema=S)

--- a/tests/test_issue_104_resolve_dtype.py
+++ b/tests/test_issue_104_resolve_dtype.py
@@ -1,0 +1,56 @@
+"""Issue #104: adapter hook for dtype resolution during expression compilation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from test_core_lazy_and_schema import SpyAdapter
+
+from planframe.backend.adapter import CompileExprContext
+from planframe.execution import execute_plan
+from planframe.expr import agg_sum, col, gt, lit
+from planframe.frame import Frame
+
+
+@dataclass(frozen=True)
+class Row:
+    id: int
+    b: int
+
+
+def test_resolve_dtype_hook_invoked_for_filter_before_select() -> None:
+    class LogAdapter(SpyAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.resolve_dtype_calls: list[str] = []
+
+        def resolve_dtype(self, name: str, *, ctx: CompileExprContext) -> object | None:
+            self.resolve_dtype_calls.append(name)
+            return super().resolve_dtype(name, ctx=ctx)
+
+    adapter = LogAdapter()
+    pf = Frame.source([{"id": 1, "b": 2}], adapter=adapter, schema=Row)
+    out = pf.filter(gt(col("b"), lit(0))).select("id")
+    _ = execute_plan(adapter=adapter, plan=out.plan(), root_data=pf._data, schema=out.schema())
+    assert "b" in adapter.resolve_dtype_calls
+
+
+def test_resolve_dtype_hook_invoked_for_agg_on_non_key_column() -> None:
+    class LogAdapter(SpyAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.resolve_dtype_calls: list[str] = []
+
+        def resolve_dtype(self, name: str, *, ctx: CompileExprContext) -> object | None:
+            self.resolve_dtype_calls.append(name)
+            return super().resolve_dtype(name, ctx=ctx)
+
+    adapter = LogAdapter()
+    pf = Frame.source(
+        [{"id": 1, "b": 10}, {"id": 1, "b": 20}],
+        adapter=adapter,
+        schema=Row,
+    )
+    out = pf.group_by("id").agg(total=agg_sum(col("b")))
+    _ = execute_plan(adapter=adapter, plan=out.plan(), root_data=pf._data, schema=out.schema())
+    assert "b" in adapter.resolve_dtype_calls

--- a/tests/test_streaming_adapter_hook.py
+++ b/tests/test_streaming_adapter_hook.py
@@ -212,8 +212,8 @@ class _StreamingSpyAdapter(
     def sample(self, df: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
         return df
 
-    def compile_expr(self, expr: object, *, schema: object | None = None) -> object:
-        _ = expr, schema
+    def compile_expr(self, expr: object, *, schema: object | None = None, ctx: object | None = None) -> object:
+        _ = expr, schema, ctx
         return expr
 
     def collect(


### PR DESCRIPTION
## Summary
Implements [issue #104](https://github.com/eddiethedean/planframe/issues/104): a standard adapter hook for dtype lookup while compiling expressions.

## Changes
- **`CompileExprContext`**: frozen dataclass with `schema` (exported from `planframe`).
- **`BaseAdapter.resolve_dtype(name, *, ctx)`**: default reads dtype from `ctx.schema`; adapters override when the schema is partial.
- **`compile_expr(..., ctx=...)`**: optional; built from `schema=` when omitted. `PlanCompileContext` always passes `ctx`.
- **Polars / pandas / sparkless**: expression lowering threads a `dtype_for` callback (ContextVar) so every `Col` triggers `resolve_dtype`.
- **SpyAdapter**: uses `collect_col_names_in_expr` so hooks run for `AggExpr` inners too.

## Tests
- `tests/test_issue_104_resolve_dtype.py`: filter → select and `group_by().agg(agg_sum(col(...)))` paths assert `resolve_dtype` sees column `b`.