### PR TITLE
feat: async execute_plan and Frame *_async aliases (fixes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this repository are documented here.
 
 ### Added
 
+- **Async public API** ([issue #105](https://github.com/eddiethedean/planframe/issues/105)): **`execute_plan_async`** (runs :func:`execute_plan` via :func:`asyncio.to_thread`) and Frame aliases **`collect_async`**, **`collect_backend_async`**, **`to_dict_async`**, **`to_dicts_async`** (wrappers around existing ``a*`` materializers).
+
 - **`BaseAdapter.resolve_dtype`**: optional hook for dtype-aware `Col(...)` lowering during `compile_expr`, with **`CompileExprContext`** (exported from `planframe`) carrying the active schema. Polars, pandas, and sparkless adapters invoke the hook for every column reference ([issue #104](https://github.com/eddiethedean/planframe/issues/104)).
 
 ## 1.1.0

--- a/docs/planframe/reference/api.md
+++ b/docs/planframe/reference/api.md
@@ -25,10 +25,14 @@ Typed mixins (import from `planframe.spark` / `planframe.pandas`, or `from planf
         - optimize
         - collect
         - acollect
+        - collect_async
+        - collect_backend_async
         - to_dicts
         - ato_dicts
+        - to_dicts_async
         - to_dict
         - ato_dict
+        - to_dict_async
 
 ## `planframe.execution_options.ExecutionOptions`
 
@@ -41,6 +45,10 @@ Typed mixins (import from `planframe.spark` / `planframe.pandas`, or `from planf
 ## `planframe.execution.execute_plan`
 
 ::: planframe.execution.execute_plan
+
+## `planframe.execution.execute_plan_async`
+
+::: planframe.execution.execute_plan_async
 
 ## `planframe.compile_context.PlanCompileContext`
 

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from planframe.backend.adapter import CompileExprContext
 from planframe.dynamic_groupby import DynamicGroupedFrame
-from planframe.execution import execute_plan
+from planframe.execution import execute_plan, execute_plan_async
 from planframe.execution_options import ExecutionOptions
 from planframe.frame import Frame
 from planframe.groupby import GroupedFrame
@@ -57,6 +57,7 @@ __all__ = [
     "ColumnSelector",
     "JoinOptions",
     "execute_plan",
+    "execute_plan_async",
     "ExecutionOptions",
     "expr",
     "spark",

--- a/packages/planframe/planframe/execution.py
+++ b/packages/planframe/planframe/execution.py
@@ -496,12 +496,15 @@ async def execute_plan_async(
     See also :meth:`planframe.frame.Frame.acollect_backend` / :meth:`~planframe.frame.Frame.collect_async`.
     """
 
-    return await asyncio.to_thread(
-        execute_plan,
-        adapter=adapter,
-        plan=plan,
-        root_data=root_data,
-        schema=schema,
-        options=options,
-        collect=collect,
+    return cast(
+        BackendFrameT,
+        await asyncio.to_thread(
+            execute_plan,
+            adapter=adapter,
+            plan=plan,
+            root_data=root_data,
+            schema=schema,
+            options=options,
+            collect=collect,
+        ),
     )

--- a/packages/planframe/planframe/execution.py
+++ b/packages/planframe/planframe/execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
@@ -474,3 +475,33 @@ def execute_plan(
     if collect:
         return adapter.collect(out, options=options)
     return out
+
+
+async def execute_plan_async(
+    *,
+    adapter: BackendAdapter[BackendFrameT, BackendExprT],
+    plan: PlanNode,
+    root_data: BackendFrameT,
+    schema: Schema,
+    options: ExecutionOptions | None = None,
+    collect: bool = False,
+) -> BackendFrameT:
+    """Async counterpart of :func:`execute_plan`.
+
+    Runs the synchronous plan interpreter in a worker thread (:func:`asyncio.to_thread`)
+    so callers can ``await`` plan execution without blocking the event loop. Transform
+    interpretation remains synchronous; pair with :meth:`~planframe.backend.adapter.BaseAdapter.acollect`
+    (or other async materializers) when the backend supports async I/O.
+
+    See also :meth:`planframe.frame.Frame.acollect_backend` / :meth:`~planframe.frame.Frame.collect_async`.
+    """
+
+    return await asyncio.to_thread(
+        execute_plan,
+        adapter=adapter,
+        plan=plan,
+        root_data=root_data,
+        schema=schema,
+        options=options,
+        collect=collect,
+    )

--- a/packages/planframe/planframe/frame/_mixin_io.py
+++ b/packages/planframe/planframe/frame/_mixin_io.py
@@ -104,6 +104,25 @@ class _HasFrameIODeps(Protocol[BackendFrameT, BackendExprT]):
         options: ExecutionOptions | None = None,
     ) -> list[dict[str, object]]: ...
 
+    async def collect_async(
+        self,
+        *,
+        name: str = ...,
+        options: ExecutionOptions | None = ...,
+    ) -> list[Any]: ...
+
+    async def collect_backend_async(
+        self, *, options: ExecutionOptions | None = ...
+    ) -> BackendFrameT: ...
+
+    async def to_dicts_async(
+        self, *, options: ExecutionOptions | None = ...
+    ) -> list[dict[str, object]]: ...
+
+    async def to_dict_async(
+        self, *, options: ExecutionOptions | None = ...
+    ) -> dict[str, list[object]]: ...
+
     def stream_dicts(
         self,
         *,
@@ -280,6 +299,43 @@ class FrameIOMixin(Generic[SchemaT, BackendFrameT, BackendExprT]):
             raise PlanFrameExecutionError(
                 f"Backend ato_dict failed for {self._adapter.name}"
             ) from e
+
+    async def collect_async(
+        self: _HasFrameIODeps[BackendFrameT, BackendExprT],
+        *,
+        name: str = "Row",
+        options: ExecutionOptions | None = None,
+    ) -> list[Any]:
+        """Alias for :meth:`acollect` (async materialize rows as schema models)."""
+
+        return await self.acollect(name=name, options=options)
+
+    async def collect_backend_async(
+        self: _HasFrameIODeps[BackendFrameT, BackendExprT],
+        *,
+        options: ExecutionOptions | None = None,
+    ) -> BackendFrameT:
+        """Alias for :meth:`acollect_backend` (async materialize backend-native frame)."""
+
+        return await self.acollect_backend(options=options)
+
+    async def to_dicts_async(
+        self: _HasFrameIODeps[BackendFrameT, BackendExprT],
+        *,
+        options: ExecutionOptions | None = None,
+    ) -> list[dict[str, object]]:
+        """Alias for :meth:`ato_dicts`."""
+
+        return await self.ato_dicts(options=options)
+
+    async def to_dict_async(
+        self: _HasFrameIODeps[BackendFrameT, BackendExprT],
+        *,
+        options: ExecutionOptions | None = None,
+    ) -> dict[str, list[object]]:
+        """Alias for :meth:`ato_dict`."""
+
+        return await self.ato_dict(options=options)
 
     def write_parquet(
         self: _HasFrameIODeps[BackendFrameT, BackendExprT],

--- a/packages/planframe/planframe/frame/_mixin_io.py
+++ b/packages/planframe/planframe/frame/_mixin_io.py
@@ -104,6 +104,19 @@ class _HasFrameIODeps(Protocol[BackendFrameT, BackendExprT]):
         options: ExecutionOptions | None = None,
     ) -> list[dict[str, object]]: ...
 
+    async def acollect(
+        self,
+        *,
+        name: str = ...,
+        options: ExecutionOptions | None = ...,
+    ) -> list[Any]: ...
+
+    async def ato_dict(
+        self,
+        *,
+        options: ExecutionOptions | None = ...,
+    ) -> dict[str, list[object]]: ...
+
     async def collect_async(
         self,
         *,

--- a/tests/pyright/pass/public_api_tooling.py
+++ b/tests/pyright/pass/public_api_tooling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from planframe import Frame, execute_plan
+from planframe import Frame, execute_plan, execute_plan_async
 from planframe.plan.walk import iter_plan_nodes
 from planframe_polars import PolarsFrame
 
@@ -15,6 +15,8 @@ pf = S({"id": [1], "a": [None]})
 # public execution API
 planned = execute_plan(adapter=pf._adapter, plan=pf.plan(), root_data=pf._data, schema=pf.schema())
 _ = pf._adapter.collect(planned)
+
+_: object = execute_plan_async
 
 # plan walking tooling
 names = [type(n).__name__ for n in iter_plan_nodes(root=pf.fill_null(0, "a").plan())]

--- a/tests/test_issue_105_async_public_api.py
+++ b/tests/test_issue_105_async_public_api.py
@@ -1,0 +1,74 @@
+"""Issue #105: discoverable async materialization aliases and execute_plan_async."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from test_core_lazy_and_schema import SpyAdapter, UserDC
+
+from planframe.execution import execute_plan, execute_plan_async
+from planframe.expr import col, eq, lit
+from planframe.frame import Frame
+
+
+def test_execute_plan_async_matches_execute_plan() -> None:
+    async def run() -> None:
+        adapter = SpyAdapter()
+        data = [{"id": 1, "age": 2}]
+        pf = Frame.source(data, adapter=adapter, schema=UserDC)
+        plan = pf.select("id").plan()
+        sync_out = execute_plan(
+            adapter=adapter, plan=plan, root_data=pf._data, schema=pf.schema()
+        )
+        async_out = await execute_plan_async(
+            adapter=adapter, plan=plan, root_data=pf._data, schema=pf.schema()
+        )
+        assert sync_out == async_out
+
+    asyncio.run(run())
+
+
+def test_execute_plan_async_propagates_errors() -> None:
+    class BoomAdapter(SpyAdapter):
+        def filter(self, df: list[dict[str, object]], predicate: object) -> list[dict[str, object]]:
+            raise RuntimeError("boom")
+
+    async def run() -> None:
+        adapter = BoomAdapter()
+        data = [{"id": 1, "age": 2}]
+        pf = Frame.source(data, adapter=adapter, schema=UserDC)
+        plan = pf.filter(eq(col("id"), lit(1))).plan()
+        with pytest.raises(RuntimeError, match="boom"):
+            await execute_plan_async(
+                adapter=adapter, plan=plan, root_data=pf._data, schema=pf.schema()
+            )
+
+    asyncio.run(run())
+
+
+def test_collect_async_to_dict_aliases_match_acollect_ato() -> None:
+    async def run() -> None:
+        adapter = SpyAdapter()
+        data = [{"id": 1, "age": 2}]
+        pf = Frame.source(data, adapter=adapter, schema=UserDC)
+        f = pf.select("id", "age")
+
+        a = await f.collect_async()
+        b = await f.acollect()
+        assert len(a) == len(b) == 1
+        assert a[0].id == b[0].id
+
+        td = await f.to_dict_async()
+        atd = await f.ato_dict()
+        assert td == atd
+
+        tds = await f.to_dicts_async()
+        atds = await f.ato_dicts()
+        assert tds == atds
+
+        backend = await f.collect_backend_async()
+        abackend = await f.acollect_backend()
+        assert backend == abackend
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
Implements [issue #105](https://github.com/eddiethedean/planframe/issues/105): first-class discoverable async execution/materialization for Frame plans.

## Changes
- **`execute_plan_async`** — async wrapper around `execute_plan` using `asyncio.to_thread`, same keyword arguments; exported from `planframe`.
- **Frame aliases** — `collect_async`, `collect_backend_async`, `to_dicts_async`, `to_dict_async` as documented aliases for `acollect`, `acollect_backend`, `ato_dicts`, `ato_dict`.
- **Docs** — `execute_plan_async` and the async Frame members listed in [API reference](docs/planframe/reference/api.md).
- **Tests** — `tests/test_issue_105_async_public_api.py` (sync/async parity, error propagation, import surface).

## Acceptance
- Adapters without async paths are unchanged; async materializers remain on `BaseAdapter` as before.
- Clear `NotImplementedError` from backends that omit async methods is existing adapter behavior.

Fixes #105.