### PR TITLE
fix(expr): Expr operator IR + typing parity (fixes #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this repository are documented here.
 
 ## Unreleased
 
+### Added
+
+- **`Expr` operator overloads** aligned with IR construction (`==`, `!=`, `&`, `|`, `~`, plus existing ordered comparisons): typing regression coverage in `tests/pyright/pass/expr_comparisons.py` and documented semantics in [typing-design](docs/planframe/design/typing-design.md) ([issue #106](https://github.com/eddiethedean/planframe/issues/106)).
+
 ## 1.2.0
 
 ### Fixed

--- a/docs/planframe/design/typing-design.md
+++ b/docs/planframe/design/typing-design.md
@@ -233,6 +233,19 @@ Filtering does not change schema.
 
 ---
 
+## 7.1 Expr operator overloads (typing semantics)
+
+PlanFrame builds expression IR from `Expr` operator overloads (`>`, `==`, `&`, `|`, `~`, …). Typing tools treat these as returning **`Expr[bool]`** (or the appropriate comparison node type) so idiomatic code type-checks:
+
+- **Comparisons** (`<`, `<=`, `>`, `>=`, `==`, `!=`): the right-hand side may be another `Expr` or a literal coerced via `lit` (`int`, `float`, `str`, `bool`, `None`, …).
+- **Boolean combinators** (`&`, `|`, `~`): operands are **`Expr`** values interpreted as boolean expressions at execution time; `&` / `|` also accept Python `bool` on the left or right (coerced to `lit(...)`), matching lazy Spark/Polars-style patterns.
+
+IR node dataclasses use `eq=False` so **operator** `==` / `!=` stay on `Expr` and produce `Eq` / `Ne` nodes instead of Python structural equality on dataclass fields.
+
+Regression coverage: `tests/pyright/pass/expr_comparisons.py` (Pyright strict) and runtime tests in `tests/test_expr_api_coverage.py`.
+
+---
+
 ## 8. Recommended Public Typing Constraints
 
 To maximize Pyright success, the public typed API should enforce these rules:

--- a/packages/planframe/planframe/expr/api.py
+++ b/packages/planframe/planframe/expr/api.py
@@ -28,163 +28,196 @@ class Expr(Generic[T]):
     def __ge__(self, other: object) -> Expr[bool]:
         return ge(cast(Expr[object], self), _coerce_expr(other))
 
+    def __eq__(self, other: object) -> Expr[bool]:  # ty: ignore[invalid-method-override]
+        return eq(cast(Expr[object], self), _coerce_expr(other))
 
-@dataclass(frozen=True, slots=True)
+    def __ne__(self, other: object) -> Expr[bool]:  # ty: ignore[invalid-method-override]
+        return ne(cast(Expr[object], self), _coerce_expr(other))
+
+    def __and__(self, other: object) -> Expr[bool]:
+        return and_(
+            cast(Expr[bool], cast(Expr[object], self)),
+            cast(Expr[bool], _coerce_expr(other)),
+        )
+
+    def __rand__(self, other: object) -> Expr[bool]:
+        return and_(
+            cast(Expr[bool], _coerce_expr(other)),
+            cast(Expr[bool], cast(Expr[object], self)),
+        )
+
+    def __or__(self, other: object) -> Expr[bool]:
+        return or_(
+            cast(Expr[bool], cast(Expr[object], self)),
+            cast(Expr[bool], _coerce_expr(other)),
+        )
+
+    def __ror__(self, other: object) -> Expr[bool]:
+        return or_(
+            cast(Expr[bool], _coerce_expr(other)),
+            cast(Expr[bool], cast(Expr[object], self)),
+        )
+
+    def __invert__(self) -> Expr[bool]:
+        return not_(cast(Expr[bool], cast(Expr[object], self)))
+
+
+@dataclass(frozen=True, slots=True, eq=False)
 class Alias(Expr[T]):
     expr: Expr[T]
     name: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Col(Expr[T]):
     name: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Lit(Expr[T]):
     value: T
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Add(Expr[object]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Eq(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Ne(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Lt(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Le(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Gt(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Ge(Expr[bool]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Sub(Expr[object]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Mul(Expr[object]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class TrueDiv(Expr[object]):
     left: Expr[object]
     right: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class IsNull(Expr[bool]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class IsNotNull(Expr[bool]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class IsIn(Expr[bool]):
     value: Expr[object]
     options: tuple[object, ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class And(Expr[bool]):
     left: Expr[bool]
     right: Expr[bool]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Or(Expr[bool]):
     left: Expr[bool]
     right: Expr[bool]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Not(Expr[bool]):
     value: Expr[bool]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Xor(Expr[bool]):
     left: Expr[bool]
     right: Expr[bool]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Abs(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Round(Expr[object]):
     value: Expr[object]
     ndigits: int | None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Floor(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Ceil(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Coalesce(Expr[object]):
     values: tuple[Expr[object], ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class IfElse(Expr[object]):
     cond: Expr[bool]
     then_value: Expr[object]
     else_value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Over(Expr[object]):
     value: Expr[object]
     partition_by: tuple[str, ...]
     order_by: tuple[str, ...] | None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Between(Expr[bool]):
     value: Expr[object]
     low: Expr[object]
@@ -192,64 +225,64 @@ class Between(Expr[bool]):
     closed: str = "both"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Clip(Expr[object]):
     value: Expr[object]
     lower: Expr[object] | None
     upper: Expr[object] | None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Pow(Expr[object]):
     base: Expr[object]
     exponent: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Exp(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Log(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrContains(Expr[bool]):
     value: Expr[object]
     pattern: str
     literal: bool = False
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrStartsWith(Expr[bool]):
     value: Expr[object]
     prefix: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrEndsWith(Expr[bool]):
     value: Expr[object]
     suffix: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrLower(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrUpper(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrLen(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrReplace(Expr[object]):
     value: Expr[object]
     pattern: str
@@ -257,38 +290,38 @@ class StrReplace(Expr[object]):
     literal: bool = False
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrStrip(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class StrSplit(Expr[object]):
     value: Expr[object]
     by: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class DtYear(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class DtMonth(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class DtDay(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Sqrt(Expr[object]):
     value: Expr[object]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class IsFinite(Expr[bool]):
     value: Expr[object]
 
@@ -296,7 +329,7 @@ class IsFinite(Expr[bool]):
 AggOpLiteral = Literal["count", "sum", "mean", "min", "max", "n_unique"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class AggExpr(Expr[object]):
     """Apply an aggregation *op* to *inner* inside :meth:`~planframe.groupby.GroupedFrame.agg`."""
 

--- a/tests/pyright/pass/expr_comparisons.py
+++ b/tests/pyright/pass/expr_comparisons.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
-from planframe.expr import col
+from planframe.expr import Expr, col, lit
 
 
 def f() -> None:
-    _ = col("age") > 0
-    _ = col("age") >= 0
-    _ = col("age") < 0
-    _ = col("age") <= 0
+    c = col("age")
+    _: Expr[bool] = c > 0
+    _: Expr[bool] = c >= 0
+    _: Expr[bool] = c < 0
+    _: Expr[bool] = c <= 0
+
+    _: Expr[bool] = c == 1
+    _: Expr[bool] = c != 1.5
+    _: Expr[bool] = c == "x"
+    _: Expr[bool] = c == True
+    _: Expr[bool] = c == None
+    _: Expr[bool] = c == lit(1)
+    _: Expr[bool] = c == col("other")
+
+    p: Expr[bool] = c > 0
+    _: Expr[bool] = p & (c < 99)
+    _: Expr[bool] = p | (c < 1)
+    _: Expr[bool] = ~p
+    _: Expr[bool] = True & p
+    _: Expr[bool] = False | p

--- a/tests/test_expr_api_coverage.py
+++ b/tests/test_expr_api_coverage.py
@@ -56,7 +56,19 @@ from planframe.expr import (
     xor,
     year,
 )
-from planframe.expr.api import _assert_bool, infer_dtype, is_bool_expr
+from planframe.expr.api import (
+    And,
+    Eq,
+    Gt,
+    Lit,
+    Lt,
+    Ne,
+    Not,
+    Or,
+    _assert_bool,
+    infer_dtype,
+    is_bool_expr,
+)
 
 
 def test_expr_api_wrappers_construct_nodes() -> None:
@@ -148,6 +160,31 @@ def test_expr_bool_narrowing_helpers() -> None:
 
     with pytest.raises(PlanFrameExpressionError, match="Expected boolean Expr"):
         _assert_bool(add(col("a"), lit(1)))
+
+
+def test_expr_operator_overloads_build_ir() -> None:
+    a = col("a")
+    b = col("b")
+    gt = a > 1
+    assert isinstance(gt, Gt) and gt.left is a and isinstance(gt.right, Lit) and gt.right.value == 1
+
+    eqn = a == 1
+    assert isinstance(eqn, Eq) and eqn.left is a and isinstance(eqn.right, Lit) and eqn.right.value == 1
+
+    neq = a != b
+    assert isinstance(neq, Ne) and neq.left is a and neq.right is b
+
+    p = a > lit(0)
+    both = p & (b < lit(1))
+    assert isinstance(both, And) and both.left is p and isinstance(both.right, Lt)
+
+    either = p | (b < lit(1))
+    assert isinstance(either, Or) and either.left is p and isinstance(either.right, Lt)
+
+    assert isinstance(~p, Not) and (~p).value is p
+
+    assert isinstance(True & p, And) and isinstance((True & p).left, Lit)
+    assert isinstance(False | p, Or) and isinstance((False | p).left, Lit)
 
 
 def test_infer_dtype_covers_common_cases() -> None:


### PR DESCRIPTION
## Summary
Fixes [issue #106](https://github.com/eddiethedean/planframe/issues/106): keep `Expr` / `Col` operator usage aligned with IR construction and static typing.

## Changes
- **Runtime**: `Expr` now implements `__eq__`, `__ne__`, `__and__`, `__rand__`, `__or__`, `__ror__`, `__invert__` so idioms like `col("x") == 1`, `(col("a") > 0) & (col("b") < 1)`, and `~` predicates build `Eq` / `And` / `Not` nodes instead of Python truthiness or dataclass equality.
- **Dataclasses**: all expression IR nodes use `eq=False` so dataclass-generated `__eq__` does not mask `Expr` operator overloads.
- **Typing**: `ty` suppressions on `__eq__`/`__ne__` only (Liskov vs `object`); Pyright strict coverage in `tests/pyright/pass/expr_comparisons.py`.
- **Docs**: new subsection in [typing-design.md](docs/planframe/design/typing-design.md); `CHANGELOG.md` Unreleased.

## Notes
- **Breaking**: structural equality between IR dataclass instances via `==` is no longer the default; use `is` / field comparison if you need object identity or value identity outside of expression IR.

Fixes #106