### PR TITLE
feat: materialize columnar boundary helpers (fixes #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this repository are documented here.
 
 ### Added
 
+- **`planframe.materialize`**: `materialize_columns` / `materialize_into` (and async `amaterialize_*`) as thin, options-preserving boundaries for columnar export and downstream factories—documented in [Creating an adapter](docs/planframe/guides/creating-an-adapter.md) ([issue #107](https://github.com/eddiethedean/planframe/issues/107)).
+
 - **`Expr` operator overloads** aligned with IR construction (`==`, `!=`, `&`, `|`, `~`, plus existing ordered comparisons): typing regression coverage in `tests/pyright/pass/expr_comparisons.py` and documented semantics in [typing-design](docs/planframe/design/typing-design.md) ([issue #106](https://github.com/eddiethedean/planframe/issues/106)).
 
 ## 1.2.0

--- a/docs/planframe/guides/creating-an-adapter.md
+++ b/docs/planframe/guides/creating-an-adapter.md
@@ -72,6 +72,18 @@ Materialization and row export happen only at execution boundaries. On `BaseAdap
 
 `Frame.collect_backend`, `Frame.to_dicts`, `Frame.to_dict`, and the async counterparts accept the same `ExecutionOptions` and pass them through to the adapter.
 
+### Columnar boundary helpers (`planframe.materialize`)
+
+For a **stable import** at the “lazy `Frame` → columnar dict” step (without pulling in Pydantic or other integrations in adapter code), use:
+
+| Helper | Behavior |
+| --- | --- |
+| `materialize_columns(frame, *, options=...)` | Same as `frame.to_dict(...)`; forwards `ExecutionOptions`. |
+| `materialize_into(frame, factory, *, options=...)` | Columnar dict → your `factory(dict[str, list[object]])` (Pydantic, dataclass batching, Arrow, etc.). |
+| `amaterialize_columns` / `amaterialize_into` | Async path (`Frame.ato_dict`); same options contract. |
+
+PlanFrame stays **generic**: it does not build models—adapters or host libraries supply the callable. Re-exported from `from planframe import ...` for discoverability.
+
 ## Async execution contract (third-party adapters)
 
 PlanFrame’s **lazy chaining is always synchronous**: building a `Frame` never does I/O and never awaits. Async support exists only at **materialization boundaries**.

--- a/docs/planframe/reference/api.md
+++ b/docs/planframe/reference/api.md
@@ -50,6 +50,10 @@ Typed mixins (import from `planframe.spark` / `planframe.pandas`, or `from planf
 
 ::: planframe.execution.execute_plan_async
 
+## `planframe.materialize`
+
+::: planframe.materialize
+
 ## `planframe.compile_context.PlanCompileContext`
 
 Internal helper shared by `Frame` and `execute_plan` for compiling expression IR and related structures. Adapter authors rarely import it directly; see [Core layout](../design/core-layout.md).

--- a/packages/planframe/planframe/__init__.py
+++ b/packages/planframe/planframe/__init__.py
@@ -18,6 +18,12 @@ from planframe.execution_options import ExecutionOptions
 from planframe.frame import Frame
 from planframe.groupby import GroupedFrame
 from planframe.ir_versions import EXPR_IR_VERSION, PLAN_IR_VERSION
+from planframe.materialize import (
+    amaterialize_columns,
+    amaterialize_into,
+    materialize_columns,
+    materialize_into,
+)
 from planframe.plan.join_options import JoinOptions
 from planframe.schema.ir import Schema
 from planframe.selector import ColumnSelector
@@ -59,6 +65,10 @@ __all__ = [
     "execute_plan",
     "execute_plan_async",
     "ExecutionOptions",
+    "materialize_columns",
+    "materialize_into",
+    "amaterialize_columns",
+    "amaterialize_into",
     "expr",
     "spark",
     "pandas",

--- a/packages/planframe/planframe/materialize.py
+++ b/packages/planframe/planframe/materialize.py
@@ -1,0 +1,73 @@
+"""Adapter-friendly materialization boundaries (columnar export + optional factory).
+
+Use these helpers when building adapters or host wrappers so ``Frame → columns`` and
+:class:`~planframe.execution_options.ExecutionOptions` forwarding stay consistent.
+PlanFrame does not construct Pydantic/dataclass models here; supply a *factory* when needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from planframe.execution_options import ExecutionOptions
+from planframe.frame import Frame
+
+TOut = TypeVar("TOut")
+
+
+def materialize_columns(
+    frame: Frame[Any, Any, Any],
+    *,
+    options: ExecutionOptions | None = None,
+) -> dict[str, list[object]]:
+    """Return columnar data for *frame* (``dict[column_name, column_values]``).
+
+    Delegates to :meth:`planframe.frame.Frame.to_dict` and forwards *options* unchanged.
+    """
+
+    return frame.to_dict(options=options)
+
+
+def materialize_into(
+    frame: Frame[Any, Any, Any],
+    factory: Callable[[dict[str, list[object]]], TOut],
+    *,
+    options: ExecutionOptions | None = None,
+) -> TOut:
+    """Materialize columns, then pass them to *factory*.
+
+    *factory* can wrap Pydantic models, dataclasses, Arrow tables, or any custom type;
+    PlanFrame stays agnostic to the output shape.
+    """
+
+    return factory(materialize_columns(frame, options=options))
+
+
+async def amaterialize_columns(
+    frame: Frame[Any, Any, Any],
+    *,
+    options: ExecutionOptions | None = None,
+) -> dict[str, list[object]]:
+    """Async columnar materialization (``Frame.ato_dict`` / ``to_dict_async``)."""
+
+    return await frame.ato_dict(options=options)
+
+
+async def amaterialize_into(
+    frame: Frame[Any, Any, Any],
+    factory: Callable[[dict[str, list[object]]], TOut],
+    *,
+    options: ExecutionOptions | None = None,
+) -> TOut:
+    """Like :func:`materialize_into`, using the async ``to_dict`` path."""
+
+    return factory(await amaterialize_columns(frame, options=options))
+
+
+__all__ = [
+    "amaterialize_columns",
+    "amaterialize_into",
+    "materialize_columns",
+    "materialize_into",
+]

--- a/tests/pyright/pass/materialize_boundary.py
+++ b/tests/pyright/pass/materialize_boundary.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from planframe import (
+    amaterialize_columns,
+    amaterialize_into,
+    materialize_columns,
+    materialize_into,
+)
+from planframe.execution_options import ExecutionOptions
+
+_: object = materialize_columns
+_: object = materialize_into
+_: object = amaterialize_columns
+_: object = amaterialize_into
+_: object = ExecutionOptions

--- a/tests/test_issue_107_materialize_boundary.py
+++ b/tests/test_issue_107_materialize_boundary.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from test_core_lazy_and_schema import SpyAdapter, UserDC
+
+from planframe import (
+    amaterialize_columns,
+    amaterialize_into,
+    materialize_columns,
+    materialize_into,
+)
+from planframe.backend.errors import PlanFrameExecutionError
+from planframe.execution_options import ExecutionOptions
+from planframe.expr import col, eq, lit
+from planframe.frame import Frame
+
+
+def _last_call(adapter: SpyAdapter, name: str) -> object | None:
+    for n, arg in reversed(adapter.calls):
+        if n == name:
+            return arg
+    return None
+
+
+def test_materialize_columns_matches_to_dict() -> None:
+    adapter = SpyAdapter()
+    data = [{"id": 1, "age": 10}, {"id": 2, "age": 20}]
+    pf = Frame.source(data, adapter=adapter, schema=UserDC)
+
+    direct = pf.to_dict()
+    via = materialize_columns(pf)
+    assert via == direct == {"id": [1, 2], "age": [10, 20]}
+
+
+def test_materialize_columns_forwards_execution_options() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
+    opts = ExecutionOptions(streaming=True, engine_streaming=False)
+
+    materialize_columns(pf, options=opts)
+
+    assert _last_call(adapter, "to_dict") == opts
+
+
+def test_materialize_into_invokes_factory_with_columns() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1, "age": 2}], adapter=adapter, schema=UserDC)
+    opts = ExecutionOptions(streaming=None, engine_streaming=True)
+
+    def factory(cols: dict[str, list[object]]) -> tuple[str, ...]:
+        return tuple(cols.keys())
+
+    out = materialize_into(pf, factory, options=opts)
+    assert out == ("id", "age")
+    assert _last_call(adapter, "to_dict") == opts
+
+
+def test_materialize_into_propagates_factory_errors() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
+
+    def boom(_: dict[str, list[object]]) -> None:
+        raise ValueError("factory failed")
+
+    with pytest.raises(ValueError, match="factory failed"):
+        materialize_into(pf, boom)
+
+
+def test_materialize_into_propagates_backend_errors() -> None:
+    class BadAdapter(SpyAdapter):
+        def to_dict(
+            self, df: list[dict[str, object]], *, options: object | None = None
+        ) -> dict[str, list[object]]:
+            raise RuntimeError("backend exploded")
+
+    adapter = BadAdapter()
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
+
+    with pytest.raises(PlanFrameExecutionError) as ei:
+        materialize_into(pf, lambda c: c)
+    assert isinstance(ei.value.__cause__, RuntimeError)
+
+
+def test_amaterialize_forwards_options() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC).filter(eq(col("id"), lit(1)))
+    opts = ExecutionOptions(streaming=True)
+
+    async def run() -> None:
+        cols = await amaterialize_columns(pf, options=opts)
+        assert cols == {"id": [1]}
+        assert _last_call(adapter, "to_dict") == opts
+
+    asyncio.run(run())
+
+
+def test_amaterialize_into() -> None:
+    adapter = SpyAdapter()
+    pf = Frame.source([{"id": 1}], adapter=adapter, schema=UserDC)
+
+    def factory(cols: dict[str, list[object]]) -> int:
+        return len(cols["id"])
+
+    async def run() -> None:
+        assert await amaterialize_into(pf, factory) == 1
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
Implements [issue #107](https://github.com/eddiethedean/planframe/issues/107): adapter-agnostic helpers for the **Frame → columnar dict** boundary with **ExecutionOptions** preserved, plus an optional **factory** hook for downstream typing (Pydantic/dataclass/etc. stay out of core).

## API (`planframe.materialize`)
- `materialize_columns(frame, *, options=...)` → `frame.to_dict(...)`
- `materialize_into(frame, factory, *, options=...)` → columns → `factory(dict[str, list[object]])`
- `amaterialize_columns` / `amaterialize_into` → `Frame.ato_dict` (async path; same options contract)

Re-exported from `from planframe import ...`.

## Docs / tests
- [Creating an adapter](docs/planframe/guides/creating-an-adapter.md): new subsection + table
- [API reference](docs/planframe/reference/api.md): mkdocstrings for `planframe.materialize`
- `tests/test_issue_107_materialize_boundary.py`: parity, options propagation, factory and backend errors
- `tests/pyright/pass/materialize_boundary.py`: import surface

Fixes #107