### PR TITLE
feat: async materialization advisory flag + adapter docs (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this repository are documented here.
 ### Added
 
 - **`CompileExprContext.resolve_backend_dtype`** and **`BaseAdapter.resolve_backend_dtype_from_frame`**: `execute_plan` wires backend-native dtype recovery when the step schema omits a column that still exists on the evaluated frame, so adapters can avoid guessed dtypes during `compile_expr` ([issue #113](https://github.com/eddiethedean/planframe/issues/113)).
+- **`AdapterCapabilities.native_async_materialize`**: advisory flag (default `False`) so hosts can distinguish default `asyncio.to_thread`-backed async materializers from adapters that override `acollect` / `ato_dicts` / `ato_dict` with native async I/O. Documented in *Creating an adapter* ([issue #115](https://github.com/eddiethedean/planframe/issues/115)).
 
 ### Documentation
 

--- a/docs/planframe/guides/creating-an-adapter.md
+++ b/docs/planframe/guides/creating-an-adapter.md
@@ -124,6 +124,26 @@ All materialization paths evaluate the plan the same way:
 - **Async-native backends**: override `acollect` and usually also `ato_dicts` / `ato_dict` to avoid blocking a worker thread.
   - Keep `acollect` focused on I/O / engine execution; plan translation should already be completed before it’s called.
 
+### Default async behavior: `asyncio.to_thread`
+
+| Location | What runs |
+| --- | --- |
+| `BaseAdapter.acollect` / `ato_dicts` / `ato_dict` | Defaults wrap the matching sync method (`collect`, `to_dicts`, `to_dict`) in `asyncio.to_thread`. The synchronous backend work does **not** run on the event-loop thread. |
+| `execute_plan_async` | Runs the synchronous `execute_plan` interpreter in a worker thread (`asyncio.to_thread`), so awaiting it avoids blocking the loop while **walking** the plan, but each adapter call inside the interpreter remains **sync** from Python’s perspective. |
+
+**Combining calls:** awaiting `execute_plan_async(...)` and then `await adapter.acollect(...)` may use **multiple** thread hops when the engine is fully synchronous. That still keeps the event loop responsive; it is **not** end-to-end async I/O unless your adapter overrides the async materializers.
+
+### Declaring native async materialization (advisory)
+
+Set **`AdapterCapabilities.native_async_materialize`** to **`True`** only when your adapter **overrides** `acollect` / `ato_dicts` / `ato_dict` so the primary backend work uses **native** `async`/`await` (HTTP clients, asyncio database drivers, …) instead of `BaseAdapter`’s default `asyncio.to_thread` around sync methods.
+
+| Value | Meaning for host libraries |
+| --- | --- |
+| `False` (default) | Matches `BaseAdapter` defaults: async entrypoints may offload sync engine calls to a thread pool. |
+| `True` | The adapter claims async materialization does **not** rely on those default thread-pooled wrappers for the main backend path. |
+
+**Contract:** PlanFrame’s `Frame` layer does **not** read this flag to change behavior today—it is **advisory** for documentation, UI, or diagnostics. Shipped adapters (Polars, pandas, sparkless) keep the default `False`.
+
 ### `ExecutionOptions` propagation
 
 `ExecutionOptions` is forwarded to:

--- a/docs/planframe/guides/migrating-since-1-1.md
+++ b/docs/planframe/guides/migrating-since-1-1.md
@@ -18,6 +18,11 @@ If you are jumping from **v1.0.x**, read [Migrating to v1.0.0](migrating-to-1-0.
 - **Documentation**: [Creating an adapter — Unknown columns during `compile_expr`](creating-an-adapter.md#unknown-columns-during-compile_expr) describes the **permissive** policy for shipped adapters (`resolve_dtype` returning `None` is a missing hint, not a compile-time error; engines typically fail at execution if the column is absent).
 - **Tests**: `tests/test_issue_114_compile_expr_unknown_column_policy.py` locks in that policy for Polars and pandas.
 
+### Async materialization: thread pool vs native async (#115)
+
+- **`AdapterCapabilities.native_async_materialize`**: advisory flag (default `False`). Set `True` when async materializers are overridden for native `async` I/O; PlanFrame does not branch on it today.
+- **Docs**: [Creating an adapter — Default async behavior](creating-an-adapter.md#default-async-behavior-asyncioto_thread) and [Declaring native async materialization](creating-an-adapter.md#declaring-native-async-materialization-advisory).
+
 ## v1.2.0
 
 ### Correctness: expression compilation uses each step’s input schema (#103)

--- a/docs/shared/glossary.md
+++ b/docs/shared/glossary.md
@@ -1,6 +1,7 @@
 # Glossary
 
 - **Adapter**: A backend implementation of `BaseAdapter` that executes PlanFrame plans.
+- **AdapterCapabilities**: Capability flags on `BaseAdapter.capabilities` (plan nodes, IO surfaces, and advisory **`native_async_materialize`** for async materialization UX). See [Creating an adapter](../planframe/guides/creating-an-adapter.md).
 - **Plan / PlanNode**: The lazy IR PlanFrame builds when you chain `Frame` operations.
 - **Expression / Expr**: The backend-agnostic expression IR compiled by adapters.
 - **ExecutionOptions**: Optional hints (`streaming`, `engine_streaming`, …) passed at materialization boundaries (`collect`, `to_dicts`, `to_dict`, and async equivalents).

--- a/packages/planframe/planframe/backend/adapter.py
+++ b/packages/planframe/planframe/backend/adapter.py
@@ -55,6 +55,9 @@ class AdapterCapabilities:
     Adapters should expose these conservatively (False unless truly supported) so
     frontend layers can decide whether to offer a method as exact parity,
     typed-parity, or explicitly unsupported.
+
+    **Advisory flags:** ``native_async_materialize`` is for host UX/docs only unless a specific
+    API documents otherwise; PlanFrame does not branch on it today.
     """
 
     # ---- Plan node capabilities (transform-time) ----
@@ -81,6 +84,12 @@ class AdapterCapabilities:
 
     # Whether `storage_options=` is accepted on IO methods that expose it.
     storage_options: bool = False
+
+    # ---- Materialization / async (advisory) ----
+    #
+    # Host libraries may read this to explain UX (thread pool vs native async). PlanFrame does
+    # not branch behavior on this flag unless explicitly documented for a specific API.
+    native_async_materialize: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_issue_115_adapter_async_capabilities.py
+++ b/tests/test_issue_115_adapter_async_capabilities.py
@@ -1,0 +1,19 @@
+"""Issue #115: advisory native_async_materialize on AdapterCapabilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from planframe.backend.adapter import AdapterCapabilities
+
+
+def test_adapter_capabilities_native_async_materialize_defaults_false() -> None:
+    assert AdapterCapabilities().native_async_materialize is False
+
+
+def test_shipped_polars_adapter_declares_thread_pooled_async_by_default() -> None:
+    pytest.importorskip("planframe_polars")
+
+    from planframe_polars import PolarsAdapter
+
+    assert PolarsAdapter().capabilities.native_async_materialize is False


### PR DESCRIPTION
## Summary

Fixes https://github.com/eddiethedean/planframe/issues/115

- **`AdapterCapabilities.native_async_materialize`** (default `False`): advisory flag for host libraries to distinguish `BaseAdapter`’s default `asyncio.to_thread` materializers from adapters that override `acollect` / `ato_dicts` / `ato_dict` with native async I/O. **PlanFrame does not branch on this flag** (documented on the dataclass and in the guide).
- **Docs** (*Creating an adapter*): new sections on default async behavior (`execute_plan_async`, thread hops) and when to set the flag; expanded async contract context.
- **Tests**: `tests/test_issue_115_adapter_async_capabilities.py` (defaults + Polars shipped adapter).
- **CHANGELOG**, **migrating since 1.1**, **glossary**.

## Verification

- `pytest`: 366 passed (4 skipped)
- `mkdocs build --strict`: clean
- `ty check`: clean