### PR TITLE
docs: third-party adapter checklist (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this repository are documented here.
 
 ### Documentation
 
+- **Third-party adapter checklist**: *Creating an adapter* adds a maintained **PlanFrame 1.2.x** markdown checklist (`BaseAdapter` abstract vs defaulted methods, `compile_expr` / `resolve_dtype`, columnar `to_dict` vs `planframe.materialize`, sync/async entrypoints); linked from the README and [typing-design](docs/planframe/design/typing-design.md) ([issue #119](https://github.com/eddiethedean/planframe/issues/119)).
+
+- **Typing CI contract**: [CONTRIBUTING.md](CONTRIBUTING.md) documents Pyright pass/fail fixtures, `ty`, and `generate_typing_stubs.py --check`; CI runs the stub parity step explicitly ([issue #118](https://github.com/eddiethedean/planframe/issues/118)).
+
 - **Adapter contract**: documented policy for **unknown column names** during `compile_expr` (permissive compile in shipped adapters; `resolve_dtype` `None` means no hint). See *Creating an adapter* ([issue #114](https://github.com/eddiethedean/planframe/issues/114)).
 - **Discoverability**: `Frame.to_dict` / `ato_dict` / async aliases and `planframe.materialize` cross-link each other; stable docs anchor `#columnar-boundary-materialize` on *Creating an adapter* ([issue #116](https://github.com/eddiethedean/planframe/issues/116)).
 - **Columnar streaming (design)**: optional `AdapterColumnarStreamer` protocol (`planframe.backend.io`) and design note `docs/planframe/design/columnar-streaming.md` for chunked columnar export ([issue #117](https://github.com/eddiethedean/planframe/issues/117)).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Key pages:
 
 - **Migrating since v1.1.0** (v1.2.0+ fixes and features): `https://planframe.readthedocs.io/en/latest/planframe/guides/migrating-since-1-1/`
 - **Creating an adapter**: `https://planframe.readthedocs.io/en/latest/planframe/guides/creating-an-adapter/`
+- **Third-party adapter checklist** (BaseAdapter surface, `compile_expr` / dtypes, columnar `materialize` vs `to_dict`, sync/async terminals): `https://planframe.readthedocs.io/en/latest/planframe/guides/creating-an-adapter/#third-party-adapter-checklist`
 - **Adapter conformance kit** (third-party `BaseAdapter` CI): `https://planframe.readthedocs.io/en/latest/planframe/guides/adapter-conformance/`
 - **Streaming rows**: `https://planframe.readthedocs.io/en/latest/planframe/guides/streaming-rows/`
 - **PySpark-like API (`planframe.spark`)**: `https://planframe.readthedocs.io/en/latest/planframe/guides/pyspark-like-api/`
@@ -134,6 +135,8 @@ Backend-specific frames (example):
 - **Not supported**: arbitrary Python UDFs / `.apply(...)` and schema-dependent compile-time column-name unions (that would require per-schema codegen).
 
 ### Development
+
+Contributor guide: **[CONTRIBUTING.md](CONTRIBUTING.md)** (Pyright fixtures, generated stub parity, `ty`).
 
 Run tests:
 

--- a/docs/planframe/design/typing-design.md
+++ b/docs/planframe/design/typing-design.md
@@ -6,6 +6,8 @@ This document defines a practical typing strategy for `Resolve`, the core mechan
 
 The goal is not to make Python's type system do arbitrary computation. The goal is to design a type system that Pyright can follow reliably across a constrained, explicit API.
 
+**Adapter authors:** runtime dtype and execution behavior live in `BaseAdapter` (`compile_expr`, `resolve_dtype`, materialization). For a per-minor-release integration checklist (sync/async, `execute_plan`, `planframe.materialize`), see [Third-party adapter integration checklist](../guides/creating-an-adapter.md#third-party-adapter-checklist).
+
 ---
 
 ## 1. Problem Statement

--- a/docs/planframe/guides/creating-an-adapter.md
+++ b/docs/planframe/guides/creating-an-adapter.md
@@ -16,7 +16,58 @@ The adapter API is the abstract base class:
 
 For a **small, published pass/fail suite** you can run in your own CI (recommended for third-party adapters), see [Adapter conformance kit](adapter-conformance.md).
 
-### How plans reach your adapter
+## Third-party adapter integration checklist (PlanFrame 1.2.x) {: #third-party-adapter-checklist }
+
+Use this list when wiring a new engine to PlanFrame. **Revisit it when upgrading PlanFrame minors**—adapter contracts and interpreter behavior can change (see `CHANGELOG.md` and [Migrating since v1.1.0](migrating-since-1-1.md)).
+
+### Design
+
+- [ ] **Frame type**: choose the backend’s native “frame” or lazy plan type (`BackendFrameT`).
+- [ ] **Expression type**: choose the backend’s expression type (`BackendExprT`) or a small wrapper.
+- [ ] **Lazy transforms**: return lazy objects from plan nodes; run backend work only inside `collect` / `to_dicts` / `to_dict` / `write_*` (or documented streaming paths).
+
+### `BaseAdapter`: implement vs override
+
+**You must implement** every `@abstractmethod` on [`BaseAdapter`](https://github.com/eddiethedean/planframe/blob/main/packages/planframe/planframe/backend/adapter.py) (grouped by role):
+
+- [ ] **Expression lowering**: `compile_expr`
+- [ ] **Materialization / export**: `collect`, `to_dicts`, `to_dict` (accept `options: ExecutionOptions | None` on each)
+- [ ] **Core transforms**: `select`, `project`, `drop`, `rename`, `with_column`, `cast`, `with_row_count`, `filter`, `sort`, `unique`, `duplicated`, `join`, `slice`, `head`, `tail`, `concat_vertical`, `concat_horizontal`, `pivot`
+- [ ] **Aggregations / reshaping**: `group_by_agg`, `group_by_dynamic_agg`, `rolling_agg`, `drop_nulls`, `fill_null`, `melt`, `explode`, `unnest`, `posexplode`, `drop_nulls_all`, `sample`
+- [ ] **Sinks** (`write_*`): `write_parquet`, `write_csv`, `write_ndjson`, `write_ipc`, `write_database`, `write_excel`, `write_delta`, `write_avro`
+
+**You may rely on defaults** (override only when needed):
+
+- **`reader` / `writer` / `areader` / `awriter`**: defaults wrap sync `read_*` / `write_*` and thread-pool async; override for custom IO surfaces or true async IO.
+- **`capabilities`**: defaults to empty flags; set conservatively so PlanFrame can fail fast on unsupported IO or declare advisory async behavior (`native_async_materialize`).
+- **`resolve_dtype`**: default merges `ctx.schema` with optional `ctx.resolve_backend_dtype`; override if you need richer dtype recovery for `Col(...)` during `compile_expr`.
+- **`resolve_backend_dtype_from_frame`**: default returns `None`; override so `execute_plan` can populate `CompileExprContext.resolve_backend_dtype` when the step schema omits a column still present on the backend frame.
+- **`acollect` / `ato_dicts` / `ato_dict`**: defaults run the sync methods in `asyncio.to_thread`; override for async-native engines.
+- **`hint`**: default no-op; override if the engine supports plan hints.
+
+### `compile_expr`, `resolve_dtype`, and unknown columns
+
+- [ ] Implement `compile_expr` so all Expr IR PlanFrame emits for your supported API surface lowers to `BackendExprT`.
+- [ ] Decide your policy for **unknown column names** (shipped adapters are **permissive** at compile time; see [Unknown columns during `compile_expr`](#unknown-columns-during-compile_expr)).
+- [ ] If projected step schemas can omit columns that still exist on the evaluated backend frame, implement **`resolve_backend_dtype_from_frame`** and/or **`resolve_dtype`** so dtypes stay accurate when possible.
+
+### Columnar boundaries: `to_dict` vs `planframe.materialize`
+
+- [ ] Implement **`to_dict`** (column-oriented) and **`to_dicts`** (row-oriented) on the adapter; they are distinct execution boundaries.
+- [ ] In wrapper libraries, prefer **`materialize_columns` / `materialize_into`** (and `amaterialize_*`) so imports and **`ExecutionOptions`** forwarding stay aligned with `Frame.to_dict` / `Frame.ato_dict`—see [Columnar boundary helpers](#columnar-boundary-materialize).
+
+### Sync vs async: `execute_plan`, `execute_plan_async`, and Frame `a*` methods
+
+- [ ] **Plan evaluation**: `execute_plan` is synchronous. `execute_plan_async` runs that interpreter in a worker thread—it does not make individual adapter calls async by itself.
+- [ ] **Frame terminals**: sync `collect_backend` / `to_dicts` / `to_dict` vs async `acollect_backend` / `ato_dicts` / `ato_dict` (and aliases like `collect_async`); async paths still build the plan synchronously, then await adapter async materializers.
+- [ ] If you only implement sync `collect` / `to_dicts` / `to_dict`, default **`acollect` / `ato_dicts` / `ato_dict`** give async API users thread-pooled behavior; override when you need native async I/O.
+- [ ] Do not bypass **`execute_plan`** from async entrypoints unless you intentionally opt out of PlanFrame’s execution semantics—see [Async execution contract](#async-execution-contract-third-party-adapters).
+
+### Typing (`Resolve`) and static analysis
+
+- [ ] For how static column types propagate on `Frame` / `Expr`, read [Resolve typing design](../design/typing-design.md) (Pyright-focused). Adapters implement runtime behavior; stubs and `Resolve` power editor/type-checker UX for host packages.
+
+## How plans reach your adapter
 
 Chaining on `Frame` records a **`PlanNode`** tree and updates the derived schema. At materialization (`collect`, `to_dicts`, `to_dict`, `write_*`, …), PlanFrame runs **`execute_plan`**, which walks that tree and invokes the matching **`BaseAdapter`** methods. Expression IR is compiled through **`PlanCompileContext`** (`planframe.compile_context`) so the same rules apply when building plans and when executing them. For a file-level map (mixins, dispatch registry, stub location), see [Core layout](../design/core-layout.md).
 
@@ -43,14 +94,13 @@ dicts=[{'id': 1, 'age': 10}, {'id': 2, 'age': 20}]
 dict={'id': [1, 2], 'age': [10, 20]}
 ```
 
-## Checklist for a real engine adapter
+## Optional: row streaming and I/O skins
 
-- **Frame type**: pick the backend’s “frame” type (e.g. a lazy plan type if it has one)
-- **Expression type**: pick the backend’s expression type (or use a small wrapper object)
-- **Always-lazy**: return lazy objects from transforms; only execute inside `collect`/`to_dicts`/writes
-- **I/O**: implement `write_*` (used by PlanFrame’s `sink_*`/`write_*`) or override `BaseAdapter.writer` with a custom writer implementation
-- **Async I/O (optional)**: override `BaseAdapter.areader` / `BaseAdapter.awriter` for true async IO (defaults wrap sync IO in `asyncio.to_thread`)
-- **Row streaming (optional)**: implement `AdapterRowStreamer` (**both** `stream_dicts` and `astream_dicts` are required for detection) to support `Frame.stream_dicts()` / `Frame.astream_dicts()` without materializing all rows at once
+Beyond the [integration checklist](#third-party-adapter-checklist):
+
+- **I/O**: implement `write_*` (used by PlanFrame’s `sink_*`/`write_*`) or override `BaseAdapter.writer` with a custom writer implementation.
+- **Async I/O (optional)**: override `BaseAdapter.areader` / `BaseAdapter.awriter` for true async IO (defaults wrap sync IO in `asyncio.to_thread`).
+- **Row streaming (optional)**: implement `AdapterRowStreamer` (**both** `stream_dicts` and `astream_dicts` are required for detection) to support `Frame.stream_dicts()` / `Frame.astream_dicts()` without materializing all rows at once—see [Optional: row streaming + true async IO](#optional-row-streaming-true-async-io) below.
 
 ## Unknown columns during `compile_expr`
 


### PR DESCRIPTION
Closes https://github.com/eddiethedean/planframe/issues/119

## Summary
- Add a PlanFrame 1.2.x third-party adapter integration checklist to creating-an-adapter.md: BaseAdapter abstract methods vs optional defaults, compile_expr / resolve_dtype, columnar to_dict vs planframe.materialize, and sync/async terminals (execute_plan, execute_plan_async, Frame a* methods).
- Link the checklist from the README (Key pages) and from typing-design.md for adapter authors using Resolve docs.
- Document in CHANGELOG.md under Unreleased.

## Verification
- mkdocs build succeeds locally.