### PR TITLE
ci/docs: typing stub parity + Expr IR pyright contract (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: ty
         run: .venv/bin/ty check
 
+      - name: Generated typing stubs (parity check)
+        run: .venv/bin/python scripts/generate_typing_stubs.py --check
+
       - name: Pytest
         run: .venv/bin/pytest -q
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to PlanFrame
+
+## Typing, stubs, and CI contract
+
+PlanFrame ships `.pyi` stubs (notably `packages/planframe/planframe/frame/__init__.pyi`) and strict Pyright fixtures so downstream packages get consistent editor feedback. The CI job enforces two layers:
+
+### 1. Pyright pass/fail fixtures (`tests/pyright/`)
+
+- **`tests/pyright/pass/*.py`** must type-check clean under **strict** Pyright (`tests/pyright/pyrightconfig.json`).
+- **`tests/pyright/fail/*.py`** must **fail** Pyright (negative tests for intentional errors).
+- The harness is `tests/test_pyright_typing.py` (marker **`typing`**).
+
+Add **`tests/pyright/pass/*.py`** files when you need a **core-only** contract (no Polars `Frame`) for `planframe.expr` IR — for example `expr_ir_public_contract.py` covers common `col` / `lit` / helper patterns so stub/runtime drift shows up in CI.
+
+### 2. Generated stub parity (`scripts/generate_typing_stubs.py`)
+
+Frame-related stubs are **generated** from Jinja templates. CI runs:
+
+```bash
+python scripts/generate_typing_stubs.py --check
+```
+
+If this fails, regenerate and commit:
+
+```bash
+python scripts/generate_typing_stubs.py
+```
+
+The same check is duplicated in **`tests/test_stub_generation_parity.py`** (marker **`typing`**) so `pytest -m typing` runs Pyright fixtures **and** the stub diff in one go.
+
+### 3. Astral `ty`
+
+First-party packages are checked with **`ty`** (see `pyproject.toml` `[tool.ty]`). It complements Pyright; keep both green on PRs.
+
+## Running tests locally
+
+```bash
+source .venv/bin/activate
+pytest
+pytest -m typing          # Pyright fixtures + stub generation check
+pytest -m "not typing"    # skip typing-only tests
+```
+
+## Documentation
+
+Docs build with MkDocs (`mkdocs build --strict` in CI). Anchor links in Markdown should resolve (use stable heading ids where needed).

--- a/docs/planframe/guides/migrating-since-1-1.md
+++ b/docs/planframe/guides/migrating-since-1-1.md
@@ -33,6 +33,11 @@ If you are jumping from **v1.0.x**, read [Migrating to v1.0.0](migrating-to-1-0.
 - **`AdapterColumnarStreamer`** (`planframe.backend.io`): optional protocol sketch for chunked `dict[str, list[object]]` batches; not yet invoked from `materialize_columns` / `Frame.to_dict`.
 - **Design:** [Columnar streaming (chunked export)](../design/columnar-streaming.md).
 
+### Typing CI: Expr stubs + generated Frame stubs (#118)
+
+- **[CONTRIBUTING.md](https://github.com/eddiethedean/planframe/blob/main/CONTRIBUTING.md)** describes the Pyright / `ty` / stub parity workflow; CI runs `scripts/generate_typing_stubs.py --check`.
+- **`tests/pyright/pass/expr_ir_public_contract.py`**: core-only `planframe.expr` contract (no Polars frame).
+
 ## v1.2.0
 
 ### Correctness: expression compilation uses each step’s input schema (#103)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,14 @@ docs = [
 [tool.hatch.build.targets.wheel]
 # Root is a workspace/meta package; nothing to ship.
 packages = []
-include = ["README.md", "LICENSE", "pyproject.toml", "CHANGELOG.md", "SECURITY.md"]
+include = [
+  "README.md",
+  "LICENSE",
+  "pyproject.toml",
+  "CHANGELOG.md",
+  "SECURITY.md",
+  "CONTRIBUTING.md",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/pyright/pass/expr_ir_public_contract.py
+++ b/tests/pyright/pass/expr_ir_public_contract.py
@@ -1,0 +1,77 @@
+"""Contract: core Expr IR + helpers type-check without Polars (stub/runtime alignment).
+
+Downstream adapters and `.pyi` surfaces rely on these patterns staying valid under Pyright
+strict mode. Extend when public `planframe.expr` API gains user-facing constructors.
+
+Use distinct locals (not repeated ``_``) so Pyright does not widen ``Expr[object]`` across lines.
+"""
+
+from __future__ import annotations
+
+from planframe.expr import (
+    Expr,
+    add,
+    agg_count,
+    agg_sum,
+    between,
+    coalesce,
+    col,
+    eq,
+    ge,
+    gt,
+    if_else,
+    is_not_null,
+    is_null,
+    isin,
+    lit,
+    mul,
+    not_,
+    or_,
+    sub,
+)
+
+
+def f() -> None:
+    """Patterns mirroring docs/quickstarts — only `planframe.expr` (no Frame)."""
+
+    a = col("a")
+    b = col("b")
+
+    arith0: Expr[object] = add(a, lit(1))
+    arith1: Expr[object] = sub(a, lit(1))
+    arith2: Expr[object] = mul(a, lit(2))
+    p0: Expr[bool] = gt(a, lit(0))
+    p1: Expr[bool] = ge(a, lit(0))
+    p2: Expr[bool] = eq(a, lit(0))
+    p3: Expr[bool] = eq(a, b)
+    p4: Expr[bool] = is_null(a)
+    p5: Expr[bool] = is_not_null(a)
+    p6: Expr[bool] = between(a, lit(0), lit(10))
+    p7: Expr[bool] = isin(a, (lit(1), lit(2)))
+    co0: Expr[object] = coalesce(a, b, lit(0))
+    if0: Expr[object] = if_else(eq(a, lit(1)), lit("one"), lit("other"))
+    p8: Expr[bool] = or_(gt(a, lit(0)), gt(b, lit(0)))
+    p9: Expr[bool] = not_(eq(a, lit(0)))
+
+    g0: Expr[object] = agg_sum(a)
+    g1: Expr[object] = agg_count(a)
+
+    _ = (
+        arith0,
+        arith1,
+        arith2,
+        p0,
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        co0,
+        if0,
+        p8,
+        p9,
+        g0,
+        g1,
+    )

--- a/tests/test_stub_generation_parity.py
+++ b/tests/test_stub_generation_parity.py
@@ -1,0 +1,32 @@
+"""CI contract: Jinja-generated `.pyi` stubs match committed templates (Frame, schema types)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.typing
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_generate_typing_stubs_check_passes() -> None:
+    """Fails when `packages/planframe/.../*.pyi` drift from `scripts/generate_typing_stubs.py`.
+
+    Same check as ``python scripts/generate_typing_stubs.py --check`` (also run in CI).
+    """
+
+    script = ROOT / "scripts" / "generate_typing_stubs.py"
+    proc = subprocess.run(
+        [sys.executable, str(script), "--check"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, (
+        "Typing stubs out of date. Run: python scripts/generate_typing_stubs.py\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )


### PR DESCRIPTION
## Summary

Closes https://github.com/eddiethedean/planframe/issues/118

### Changes
- **CI**: Run `scripts/generate_typing_stubs.py --check` after `ty` so generated Frame/schema stubs stay aligned with templates.
- **Docs**: Add `CONTRIBUTING.md` describing Pyright pass/fail fixtures, `ty`, stub generation check, and local `pytest -m typing`; link from migrating guide and ship in the wheel via `pyproject.toml`.
- **Contract tests**: `tests/pyright/pass/expr_ir_public_contract.py` for core `planframe.expr` IR patterns; `tests/test_stub_generation_parity.py` (typing marker) mirrors the CI stub check.

### Acceptance
- CI step + scope documented in `CONTRIBUTING.md`.